### PR TITLE
Generate bulge attribute

### DIFF
--- a/tools/includes/vrv/config.yml
+++ b/tools/includes/vrv/config.yml
@@ -116,6 +116,8 @@ mapped:
 defaults:
     data_ARTICULATION_List:
         std::vector<data_ARTICULATION>()
+    data_BULGE:
+        std::vector<std::pair<double, double>>()
     data_COMPASSDIRECTION:
         data_COMPASSDIRECTION()
     data_EVENTREL:
@@ -194,6 +196,9 @@ modules:
         att.barLine.log:
             form:
                 default: BARRENDITION_single
+        att.curvature:
+            bulge:
+                type: data_BULGE
         att.duration.ratio:
             num:
                 default: -1

--- a/tools/langs/cplusplus_vrv.py
+++ b/tools/langs/cplusplus_vrv.py
@@ -425,7 +425,7 @@ def vrv_load_config(includes_dir):
         return
     
     f = open(config, "r")
-    CONFIG = yaml.load(f)
+    CONFIG = yaml.load(f, Loader=yaml.FullLoader)
     f.close()
     
 def vrv_get_att_config(module, gp, att):


### PR DESCRIPTION
This PR changes the configuration to support the bulge attribute. We also replace a [deprecated PyYAML-function](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation).