### PR TITLE
Change stem length default

### DIFF
--- a/tools/includes/vrv/config.yml
+++ b/tools/includes/vrv/config.yml
@@ -179,6 +179,11 @@ modules:
             artic.ges:
                 type: data_ARTICULATION_List
 
+    mensural:
+        att.stem.vis:
+            len:
+                default: -1.0
+
     shared:
         att.articulation:
             artic:
@@ -217,7 +222,7 @@ modules:
         att.stems:
             stem.len:
                 type: double
-                default: -1
+                default: -1.0
         att.timestamp.logical:
             tstamp:
                 default: -1.0


### PR DESCRIPTION
This PR changes the default of stem length attributes. Those should be nonzero such that _HasAttribute_ evaluates to `True` whenever we prescribe a zero stem length.