### PR TITLE
Proposal: replace default integer value with macro

### DIFF
--- a/tools/includes/vrv/config.yml
+++ b/tools/includes/vrv/config.yml
@@ -162,8 +162,6 @@ defaults:
         -1.0
     data_PERCENT_LIMITED:
         -1.0
-    data_PERCENT_LIMITED_SIGNED:
-        VRV_UNSET
     data_STAFFITEM:
         data_STAFFITEM()
     data_STAFFREL:
@@ -180,35 +178,17 @@ modules:
         att.articulation.gestural:
             artic.ges:
                 type: data_ARTICULATION_List
-        att.duration.gestural:
-            dots.ges:
-                default: -1
-
-    mensural:
-        att.mensural.log:
-            proport.num:
-                default: -1
-            proport.numbase:
-                default: -1
 
     shared:
         att.articulation:
             artic:
                 type: data_ARTICULATION_List
-        att.augmentDots:
-            dots:
-                default: -1
         att.barLine.log:
             form:
                 default: BARRENDITION_single
         att.curvature:
             bulge:
                 type: data_BULGE
-        att.duration.ratio:
-            num:
-                default: -1
-            numbase:
-                default: -1
         att.keySig.log:
             sig:
                 type: data_KEYSIGNATURE
@@ -225,19 +205,12 @@ modules:
                 type: data_METERCOUNT_pair
             meter.unit:
                 type: int
-        att.nInteger:
-            n:
-                type: int
-                default: -1
         att.nNumberLike:
             n:
                 type: std::string
         att.plist:
             plist:
                 type: xsdAnyURI_List
-        att.staffLoc:
-            loc:
-                default: VRV_UNSET
         att.staffIdent:
             staff:
                 type: xsdPositiveInteger_List
@@ -248,25 +221,11 @@ modules:
         att.timestamp.logical:
             tstamp:
                 default: -1.0
-        att.transposition:
-            trans.diat:
-                default: VRV_UNSET
-            trans.semi:
-                default: VRV_UNSET
-        att.verticalAlignment:
-            vgrp:
-                type: int
-                default: VRV_UNSET
 
     frettab:
         att.note.ges.tab:
             tab.fret:
                 type: int
-                default: -1
-
-    visual:
-        att.fTrem.vis:
-            beams.float:
                 default: -1
 
 att-classes:

--- a/tools/langs/cplusplus_vrv.py
+++ b/tools/langs/cplusplus_vrv.py
@@ -519,7 +519,7 @@ def vrv_getattdefault(schema, module, gp, aname, includes_dir = ""):
     
     if attype == "int":
         if default == None:
-            default = 0
+            default = "VRV_UNSET"
         return ("{0}".format(default), "", ["StrToInt", "IntToStr"])
     elif attype == "char":
         if default == None:


### PR DESCRIPTION
Instead of overwriting each default integer value we could use the `VRV_UNSET` macro directly in LibMEI.

Additionally we could then define it directly in `atttypes.h`.
