### PR TITLE
Set att.transposition to int

### DIFF
--- a/tools/includes/vrv/config.yml
+++ b/tools/includes/vrv/config.yml
@@ -221,6 +221,11 @@ modules:
         att.timestamp.logical:
             tstamp:
                 default: -1.0
+        att.transposition:
+            trans.diat:
+                type: int
+            trans.semi:
+                type: int
 
     frettab:
         att.note.ges.tab:


### PR DESCRIPTION
This fixes and improves a change from the previous PR by setting `trans.diat` and `trans.semi` to type int.
Corresponding PR for the schema is here: https://github.com/music-encoding/music-encoding/pull/975