### PR TITLE
Reset barrendition default

### DIFF
--- a/tools/includes/vrv/config.yml
+++ b/tools/includes/vrv/config.yml
@@ -183,9 +183,6 @@ modules:
         att.articulation:
             artic:
                 type: data_ARTICULATION_List
-        att.barLine.log:
-            form:
-                default: BARRENDITION_single
         att.curvature:
             bulge:
                 type: data_BULGE

--- a/tools/langs/cplusplus_vrv.py
+++ b/tools/langs/cplusplus_vrv.py
@@ -1,14 +1,12 @@
  # -- coding: utf-8 --
 
-import sys
+import logging
 import os
 import re
-import codecs
+import sys
 import textwrap
-import logging
-import types
+
 lg = logging.getLogger('schemaparser')
-import pdb
 
 import yaml
 


### PR DESCRIPTION
This PR brings the change from https://github.com/rism-digital/verovio/pull/2999 to LibMEI.
Also it's a small script clean-up, removing the unused imports.