### PR TITLE
Update tools

### DIFF
--- a/tools/includes/vrv/config.yml
+++ b/tools/includes/vrv/config.yml
@@ -223,11 +223,6 @@ modules:
         att.timestamp.logical:
             tstamp:
                 default: -1.0
-        att.transposition:
-            trans.diat:
-                type: int
-            trans.semi:
-                type: int
 
     frettab:
         att.note.ges.tab:

--- a/tools/langs/__init__.py
+++ b/tools/langs/__init__.py
@@ -1,1 +1,1 @@
-AVAILABLE_LANGS = ["C++", "Python", "ManuScript", "Java"]
+AVAILABLE_LANGS = ("cpp", "csharp", "java", "manuscript", "python", "vrv")

--- a/tools/langs/__init__.py
+++ b/tools/langs/__init__.py
@@ -1,1 +1,1 @@
-AVAILABLE_LANGS = ("cpp", "csharp", "java", "manuscript", "python", "vrv")
+AVAILABLE_LANGS = ("cpp", "csharp", "java", "manuscript", "python", "vrv", "vdoc")

--- a/tools/langs/cplusplus.py
+++ b/tools/langs/cplusplus.py
@@ -67,8 +67,8 @@ CLASSES_HEAD_TEMPLATE = """{license}
 
 namespace mei {{
 {elements}
-}}
-#endif  // {moduleNameCaps}_H_
+}} // namespace mei
+#endif // {moduleNameCaps}_H_
 """
 
 ELEMENT_CLASS_HEAD_TEMPLATE = """

--- a/tools/langs/cplusplus.py
+++ b/tools/langs/cplusplus.py
@@ -352,7 +352,7 @@ def __create_element_classes(schema, outdir):
 
         incl_output = ""
         incl_output += "#include \"meicommon.h\"\n"
-        for incl in includes:
+        for incl in sorted(includes):
             incl_output += "#include \"{0}mixins.h\"\n".format(incl.lower())
 
         outvars = {

--- a/tools/langs/cplusplus.py
+++ b/tools/langs/cplusplus.py
@@ -234,7 +234,7 @@ def __create_mixin_classes(schema, outdir):
         if "std::string" in classes:
             tplvars["includes"] = "#include <string>"
         fullout = CLASSES_HEAD_TEMPLATE.format(**tplvars)
-        fmh = Path(outdir, "{0}mixins.h".format(module.lower()))
+        fmh = Path(outdir, f"{module.lower()}mixins.h")
         fmh.write_text(fullout)
         lg.debug("\tCreated {0}mixins.h".format(module.lower()))
 

--- a/tools/langs/cplusplus.py
+++ b/tools/langs/cplusplus.py
@@ -288,13 +288,13 @@ def __create_mixin_classes(schema, outdir):
             classes += MIXIN_CLASS_IMPL_CONS_TEMPLATE.format(**clsubstr)
 
         tplvars = {
-            "moduleNameLower": "{0}mixins".format(module.lower()),
+            "moduleNameLower": f"{module.lower()}mixins",
             "elements": classes
         }
         fullout = CLASSES_IMPL_TEMPLATE.format(**tplvars)
-        fmi = Path(outdir, "{0}mixins.cpp".format(module.lower()))
+        fmi = Path(outdir, f"{module.lower()}mixins.cpp")
         fmi.write_text(fullout)
-        lg.debug("\tCreated {0}mixins.cpp".format(module.lower()))
+        lg.debug(f"\tCreated {module.lower()}mixins.cpp")
 
 
 def __create_element_classes(schema, outdir):
@@ -365,9 +365,9 @@ def __create_element_classes(schema, outdir):
             outvars["includes"] += "#include <string>\n"
 
         fullout = CLASSES_HEAD_TEMPLATE.format(**outvars)
-        fmh = Path(outdir, "{0}.h".format(module.lower()))
+        fmh = Path(outdir, f"{module.lower()}.h")
         fmh.write_text(fullout)
-        lg.debug("\tCreated {0}.h".format(module.lower()))
+        lg.debug(f"\tCreated {module.lower()}.h")
 
     # ###########################################################################
     # # Implementation
@@ -436,9 +436,9 @@ def __create_element_classes(schema, outdir):
         }
         fullout = CLASSES_IMPL_TEMPLATE.format(**implvars)
 
-        fmi = Path(outdir, "{0}.cpp".format(module.lower()))
+        fmi = Path(outdir, f"{module.lower()}.cpp")
         fmi.write_text(fullout)
-        lg.debug("\t Created {0}.cpp".format(module.lower()))
+        lg.debug(f"\t Created {module.lower()}.cpp")
 
 
 def parse_includes(file_dir, includes_dir: str):
@@ -460,7 +460,7 @@ def __process_include(fname, includes, includes_dir: str):
     new_methods, includes_block = None, None
     if "{0}.inc".format(fname) in includes:
         lg.debug("\tProcessing include for {0}".format(fname))
-        includefile = Path(includes_dir, "{0}.inc".format(fname)).read_text()
+        includefile = Path(includes_dir, fname).with_suffix(".inc").read_text()
         new_methods, includes_block = __parse_includefile(includefile)
         return (new_methods, includes_block)
     else:

--- a/tools/langs/cplusplus.py
+++ b/tools/langs/cplusplus.py
@@ -1,9 +1,9 @@
 # -- coding: utf-8 --
-import sys
-import os
+import logging
 import re
 import textwrap
-import logging
+from pathlib import Path
+
 lg = logging.getLogger('schemaparser')
 
 LANG_NAME = "C++"
@@ -76,7 +76,7 @@ ELEMENT_CLASS_HEAD_TEMPLATE = """
 class MEI_EXPORT {elementNameUpper} : public MeiElement {{
     public:
         {elementNameUpper}();
-        {elementNameUpper}(const {elementNameUpper}& other);
+        {elementNameUpper}(const {elementNameUpper} &other);
         virtual ~{elementNameUpper}();
 {methods}
 /* include <{elementName}> */
@@ -92,7 +92,7 @@ ELEMENT_CLASS_IMPL_CONS_TEMPLATE = """mei::{elementNameUpper}::{elementNameUpper
 }}
 REGISTER_DEFINITION(mei::{elementNameUpper}, \"{elementNameLower}\");
 mei::{elementNameUpper}::~{elementNameUpper}() {{}}
-mei::{elementNameUpper}::{elementNameUpper}(const {elementNameUpper}& other) :
+mei::{elementNameUpper}::{elementNameUpper}(const {elementNameUpper} &other) :
     MeiElement(other){onlyMixIns}
 {{
 }}
@@ -159,15 +159,12 @@ def create(schema, outdir):
 
 
 def __get_docstr(text, indent=0):
-    """ Format a docstring. Take the first sentence (. followed by a space)
+    """ 
+        Format a docstring. Take the first sentence (. followed by a space)
         and use it for the brief. Then put the rest of the text after a blank
-        line if there is text there
+        line if there is text there.
     """
-    # string handling is handled differently in Python 3+
-    if sys.version_info >= (3, 0):
-        text = text.strip()
-    else:
-        text = text.strip().encode("utf-8")
+    text = text.strip()
 
     dotpos = text.find(". ")
     if dotpos > 0:
@@ -212,7 +209,7 @@ def __create_mixin_classes(schema, outdir):
             for att in atts:
                 if len(att.split("|")) > 1:
                     ns, att = att.split("|")
-                docstr = __get_docstr(schema.getattdocs(att), indent=8)
+                docstr = __get_docstr(schema.get_att_desc(att), indent=8)
                 substrings = {
                     "attNameUpper": schema.cc(schema.strpatt(att)),
                     "attNameLower": att,
@@ -231,15 +228,14 @@ def __create_mixin_classes(schema, outdir):
         tplvars = {
             "includes": "",
             'license': LICENSE.format(authors=AUTHORS),
-            'moduleNameCaps': "{0}MIXIN".format((module.upper()).replace("-","_")),
+            'moduleNameCaps': "{0}MIXIN".format((module.upper()).replace("-", "_")),
             'elements': classes.strip()
         }
         if "std::string" in classes:
             tplvars["includes"] = "#include <string>"
         fullout = CLASSES_HEAD_TEMPLATE.format(**tplvars)
-        fmh = open(os.path.join(outdir, "{0}mixins.h".format(module.lower())), 'w')
-        fmh.write(fullout)
-        fmh.close()
+        fmh = Path(outdir, "{0}mixins.h".format(module.lower()))
+        fmh.write_text(fullout)
         lg.debug("\tCreated {0}mixins.h".format(module.lower()))
 
     lg.debug("Creating Mixin Implementations")
@@ -296,9 +292,8 @@ def __create_mixin_classes(schema, outdir):
             "elements": classes
         }
         fullout = CLASSES_IMPL_TEMPLATE.format(**tplvars)
-        fmi = open(os.path.join(outdir, "{0}mixins.cpp".format(module.lower())), 'w')
-        fmi.write(fullout)
-        fmi.close()
+        fmi = Path(outdir, "{0}mixins.cpp".format(module.lower()))
+        fmi.write_text(fullout)
         lg.debug("\tCreated {0}mixins.cpp".format(module.lower()))
 
 
@@ -324,24 +319,27 @@ def __create_element_classes(schema, outdir):
                         if len(sda.split("|")) > 1:
                             ns, sda = sda.split("|")
 
-                        docstr = __get_docstr(schema.getattdocs(sda), indent=8)
+                        docstr = __get_docstr(
+                            schema.get_att_desc(sda), indent=8)
                         methstr = {
                             "attNameUpper": schema.cc(schema.strpatt(sda)),
                             "attNameLower": sda,
                             "attNameLowerJoined": schema.strpdot(sda),
                             "documentation": docstr
                         }
-                        attribute_methods += METHODS_HEADER_TEMPLATE.format(**methstr)
+                        attribute_methods += METHODS_HEADER_TEMPLATE.format(
+                            **methstr)
 
                 else:
-                    element_mixins += ELEMENT_MIXIN_TEMPLATE.format(attNameUpper=schema.cc(schema.strpatt(attribute)))
+                    element_mixins += ELEMENT_MIXIN_TEMPLATE.format(
+                        attNameUpper=schema.cc(schema.strpatt(attribute)))
 
                     # figure out includes
-                    if attribute in schema.inverse_attribute_group_structure.keys():
+                    if attribute in list(schema.inverse_attribute_group_structure.keys()):
                         mod = schema.inverse_attribute_group_structure[attribute]
                         if mod not in includes:
                             includes.append(mod)
-            docstr = __get_docstr(schema.geteldocs(element), indent=0)
+            docstr = __get_docstr(schema.get_elem_desc(element), indent=0)
             elvars = {
                 "elementNameUpper": schema.cc(element),
                 "methods": attribute_methods,
@@ -360,16 +358,15 @@ def __create_element_classes(schema, outdir):
         outvars = {
             "includes": incl_output,
             "license": LICENSE.format(authors=AUTHORS),
-            "moduleNameCaps": (module.upper()).replace("-","_"),
+            "moduleNameCaps": (module.upper()).replace("-", "_"),
             "elements": element_output.strip()
         }
         if "std::string" in element_output:
             outvars["includes"] += "#include <string>\n"
 
         fullout = CLASSES_HEAD_TEMPLATE.format(**outvars)
-        fmh = open(os.path.join(outdir, "{0}.h".format(module.lower())), 'w')
-        fmh.write(fullout)
-        fmh.close()
+        fmh = Path(outdir, "{0}.h".format(module.lower()))
+        fmh.write_text(fullout)
         lg.debug("\tCreated {0}.h".format(module.lower()))
 
     # ###########################################################################
@@ -411,12 +408,16 @@ def __create_element_classes(schema, outdir):
                             "attNameLowerJoined": schema.strpdot(sda),
                             # "namespaceDefinition": nsDef,
                             "attrNs": attrNs,
-                            "accessor": "",  # we need this for mixins, but not for elements.
+                            # we need this for mixins, but not for elements.
+                            "accessor": "",
                         }
-                        attribute_methods += METHODS_IMPL_TEMPLATE.format(**methstr)
+                        attribute_methods += METHODS_IMPL_TEMPLATE.format(
+                            **methstr)
                 else:
-                    element_mixins += "    m_{0}(this),\n".format(schema.cc(schema.strpatt(attribute)))
-                    element_onlymixins += ",\n    m_{0}(this)".format(schema.cc(schema.strpatt(attribute)))
+                    element_mixins += "    m_{0}(this),\n".format(
+                        schema.cc(schema.strpatt(attribute)))
+                    element_onlymixins += ",\n    m_{0}(this)".format(
+                        schema.cc(schema.strpatt(attribute)))
             element_mixins = element_mixins.rstrip(",\n")
 
             consvars = {
@@ -426,7 +427,8 @@ def __create_element_classes(schema, outdir):
                 'onlyMixIns': element_onlymixins,
                 'methods': attribute_methods
             }
-            element_constructor += ELEMENT_CLASS_IMPL_CONS_TEMPLATE.format(**consvars)
+            element_constructor += ELEMENT_CLASS_IMPL_CONS_TEMPLATE.format(
+                **consvars)
 
         implvars = {
             'moduleNameLower': module.lower(),
@@ -434,35 +436,31 @@ def __create_element_classes(schema, outdir):
         }
         fullout = CLASSES_IMPL_TEMPLATE.format(**implvars)
 
-        fmi = open(os.path.join(outdir, "{0}.cpp".format(module.lower())), 'w')
-        fmi.write(fullout)
-        fmi.close()
+        fmi = Path(outdir, "{0}.cpp".format(module.lower()))
+        fmi.write_text(fullout)
         lg.debug("\t Created {0}.cpp".format(module.lower()))
 
 
-def parse_includes(file_dir, includes_dir):
+def parse_includes(file_dir, includes_dir: str):
+    """Parse includes."""
     lg.debug("Parsing includes")
-
     # get the files in the includes directory
-    includes = [f for f in os.listdir(includes_dir) if not f.startswith(".")]
+    includes = [f for f in Path(includes_dir).iterdir()
+                if not f.name.startswith(".")]
 
-    for dp, dn, fn in os.walk(file_dir):
-        for f in fn:
-            if f.startswith("."):
-                continue
-            methods, inc = __process_include(f, includes, includes_dir)
-            if methods:
-                __parse_codefile(methods, inc, dp, f)
+    for f in Path(file_dir).iterdir():
+        if f.name.startswith("."):
+            continue
+        methods, inc = __process_include(f, includes, includes_dir)
+        if methods:
+            __parse_codefile(methods, inc, f.parent, f)
 
 
-def __process_include(fname, includes, includes_dir):
-    name, ext = os.path.splitext(fname)
+def __process_include(fname, includes, includes_dir: str):
     new_methods, includes_block = None, None
     if "{0}.inc".format(fname) in includes:
         lg.debug("\tProcessing include for {0}".format(fname))
-        f = open(os.path.join(includes_dir, "{0}.inc".format(fname)), 'r')
-        includefile = f.read()
-        f.close()
+        includefile = Path(includes_dir, "{0}.inc".format(fname)).read_text()
         new_methods, includes_block = __parse_includefile(includefile)
         return (new_methods, includes_block)
     else:
@@ -473,19 +471,20 @@ def __parse_includefile(contents):
     # parse the include file for our methods.
     ret = {}
     inc = []
-    reg = re.compile(r"/\* <(?P<elementName>[^>]+)> \*/(.+?)/\* </(?P=elementName)> \*/", re.MULTILINE | re.DOTALL)
+    reg = re.compile(
+        r"/\* <(?P<elementName>[^>]+)> \*/(.+?)/\* </(?P=elementName)> \*/", re.MULTILINE | re.DOTALL)
     ret = dict(re.findall(reg, contents))
 
     # grab the include for the includes...
-    reginc = re.compile(r"/\* #include_block \*/(.+?)/\* #include_block \*/", re.MULTILINE | re.DOTALL)
+    reginc = re.compile(
+        r"/\* #include_block \*/(.+?)/\* #include_block \*/", re.MULTILINE | re.DOTALL)
     inc = re.findall(reginc, contents)
     return (ret, inc)
 
 
 def __parse_codefile(methods, includes, directory, codefile):
-    f = open(os.path.join(directory, codefile), 'r')
-    contents = f.readlines()
-    f.close()
+    f = Path(directory, codefile)
+    contents = f.read_text()
     regmatch = re.compile(r"/\* include <(?P<elementName>[^>]+)> \*/")
     incmatch = re.compile(r"/\* #include_block \*/")
     for i, line in enumerate(contents):
@@ -497,16 +496,6 @@ def __parse_codefile(methods, includes, directory, codefile):
         match = re.match(regmatch, line)
         if match:
             if match.group("elementName") in methods.keys():
-                contents[i] = methods[match.group("elementName")].lstrip("\n") + "\n"
+                contents[i] = methods[match.group("elementName")].lstrip("\n")
 
-    f = open(os.path.join(directory, codefile), 'w')
-    f.writelines(contents)
-    f.close()
-
-
-
-
-
-
-
-
+    f.write_text(contents)

--- a/tools/langs/cplusplus_vrv.py
+++ b/tools/langs/cplusplus_vrv.py
@@ -482,7 +482,8 @@ def vrv_getatttype(schema, module, gp, aname, includes_dir: str = ""):
     # First numbers
     el = schema.xpath("//tei:attDef[@ident=$name]/tei:datatype/rng:data/@type", name=aname, namespaces=TEI_RNG_NS)
     if el:
-        if el[0] == "nonNegativeInteger" or el[0] == "positiveInteger":
+        if el[0].endswith("nteger"):
+            # We unify "integer", "positiveInteger", and "nonNegativeInteger"
             return ("int", "")
         elif el[0] == "decimal":
             return ("double", "")

--- a/tools/langs/cplusplus_vrv.py
+++ b/tools/langs/cplusplus_vrv.py
@@ -1,10 +1,9 @@
  # -- coding: utf-8 --
 
 import logging
-import os
 import re
-import sys
 import textwrap
+from pathlib import Path
 
 lg = logging.getLogger('schemaparser')
 
@@ -409,22 +408,19 @@ def vrv_converter_cc(name):
     return l[0].upper() + l[1:] + r
 
 # globals
-TEI_NS = {"tei": "http://www.tei-c.org/ns/1.0", "rng": "http://relaxng.org/ns/structure/1.0"}
+TEI_RNG_NS = {"tei": "http://www.tei-c.org/ns/1.0",
+              "rng": "http://relaxng.org/ns/structure/1.0"}
 
-def vrv_load_config(includes_dir):
-    """ Load the vrv attribute overrides into CONFIG."""
+def vrv_load_config(includes_dir: str):
+    """Load the vrv attribute overrides into CONFIG."""
     global CONFIG
-    
-    if not includes_dir:
-        return
         
-    config = os.path.join(includes_dir, "config.yml")
-    if not os.path.isfile(config):
+    config = Path(includes_dir, "config.yml")
+    if not config.exists():
         return
     
-    f = open(config, "r")
+    f = config.open("r")
     CONFIG = yaml.load(f, Loader=yaml.FullLoader)
-    f.close()
     
 def vrv_get_att_config(module, gp, att):
     if not module in CONFIG["modules"] or not gp in CONFIG["modules"][module]:
@@ -449,7 +445,7 @@ def vrv_is_alternate_type(type):
     return True
 
 def vrv_get_att_config_type(module, gp, att):
-    """ Get the att type."""
+    """Get the att type."""
     att_config = vrv_get_att_config(module, gp, att)
     if att_config is None or "type" not in att_config:
         return None, "" 
@@ -457,7 +453,7 @@ def vrv_get_att_config_type(module, gp, att):
     return (att, "")
     
 def vrv_get_att_config_default(module, gp, att):
-    """ Get the att default value."""
+    """Get the att default value."""
     att_config = vrv_get_att_config(module, gp, att)
     # nothing in the module/att
     if att_config is None or "default" not in att_config:
@@ -473,8 +469,8 @@ def vrv_getformattedtype(type):
 def vrv_getformattedvallist(att, vallist):
     return "{0}_{1}".format(vrv_member_cc(att.replace("att.","")), vallist.upper().replace(".","").replace(":",""))
 
-def vrv_getatttype(schema, module, gp, aname, includes_dir = ""):   
-    """ returns the attribut type for element name, or string if not detectable."""
+def vrv_getatttype(schema, module, gp, aname, includes_dir: str = ""):   
+    """Returns the attribute type for element name, or string if not detectable."""
     
     # Look up if there is an override for this type in the current module, and return it
     # Note that we do not honor pseudo-hungarian notation
@@ -484,33 +480,33 @@ def vrv_getatttype(schema, module, gp, aname, includes_dir = ""):
     
     # No override, get it from the schema
     # First numbers
-    el = schema.xpath("//tei:attDef[@ident=$name]/tei:datatype/rng:data/@type", name=aname, namespaces=TEI_NS)
+    el = schema.xpath("//tei:attDef[@ident=$name]/tei:datatype/rng:data/@type", name=aname, namespaces=TEI_RNG_NS)
     if el:
         if el[0] == "nonNegativeInteger" or el[0] == "positiveInteger":
             return ("int", "")
         elif el[0] == "decimal":
             return ("double", "")
     # The data types
-    ref = schema.xpath("//tei:classSpec[@ident=$gp]//tei:attDef[@ident=$name]/tei:datatype/rng:ref/@name", gp=gp, name=aname, namespaces=TEI_NS)
+    ref = schema.xpath("//tei:classSpec[@ident=$gp]//tei:attDef[@ident=$name]/tei:datatype/rng:ref/@name", gp=gp, name=aname, namespaces=TEI_RNG_NS)
     if ref:
         return (vrv_getformattedtype("{0}".format(ref[0])), "")
     # Finally from val lists
-    vl = schema.xpath("//tei:classSpec[@ident=$gp]//tei:attDef[@ident=$name]/tei:valList[@type=\"closed\"]", gp=gp, name=aname, namespaces=TEI_NS)
+    vl = schema.xpath("//tei:classSpec[@ident=$gp]//tei:attDef[@ident=$name]/tei:valList[@type=\"closed\"]", gp=gp, name=aname, namespaces=TEI_RNG_NS)
     if vl:
-        element = vl[0].xpath("./ancestor::tei:classSpec", namespaces=TEI_NS)
-        attName = vl[0].xpath("./parent::tei:attDef/@ident", namespaces=TEI_NS)
+        element = vl[0].xpath("./ancestor::tei:classSpec", namespaces=TEI_RNG_NS)
+        attName = vl[0].xpath("./parent::tei:attDef/@ident", namespaces=TEI_RNG_NS)
         if element:
             return(vrv_getformattedvallist(element[0].get("ident"),attName[0]), "")
             #data_list = "{0}.{1}".format(element[0].get("ident"),attName[0])
         #elif attName:
-        #    elName = vl[0].xpath("./ancestor::tei:elementSpec/@ident", namespaces=TEI_NS)
+        #    elName = vl[0].xpath("./ancestor::tei:elementSpec/@ident", namespaces=TEI_RNG_NS)
         #    lg.debug("VALLIST {0} --- {1}".format(elName[0],attName[0]))
     
     # Otherwise as string
     return ("std::string", "")
 
-def vrv_getattdefault(schema, module, gp, aname, includes_dir = ""):        
-    """ returns the attribute default value for element name, or string if not detectable."""
+def vrv_getattdefault(schema, module, gp, aname, includes_dir: str = ""):        
+    """Returns the attribute default value for element name, or string if not detectable."""
     
     attype, hungarian = vrv_getatttype(schema, module, gp, aname, includes_dir)
     default = vrv_get_att_config_default(module, gp, aname)
@@ -536,7 +532,7 @@ def vrv_getattdefault(schema, module, gp, aname, includes_dir = ""):
         return ("{0}".format(default), "", ["StrTo{0}".format(cname), "{0}ToStr".format(cname)])
 
 def create(schema, outdir, includes_dir = ""):
-    lg.debug("Begin Verovio C++ Output ... ")
+    lg.debug("Begin Verovio C++ Output ...")
     
     vrv_load_config(includes_dir)
     __create_att_classes(schema, outdir, includes_dir)
@@ -544,15 +540,12 @@ def create(schema, outdir, includes_dir = ""):
     lg.debug("Success!")
 
 def __get_docstr(text, indent=0):
-    """ Format a docstring. Take the first sentence (. followed by a space)
+    """
+        Format a docstring. Take the first sentence (. followed by a space)
         and use it for the brief. Then put the rest of the text after a blank
         line if there is text there
     """
-    # string handling is handled differently in Python 3+
-    if sys.version_info >= (3, 0):
-        text = text.strip()
-    else:
-        text = text.strip().encode("utf-8")
+    text = text.strip()
     dotpos = text.find(". ")
     if dotpos > 0:
         brief = text[:dotpos+1]
@@ -608,7 +601,7 @@ def __create_att_classes(schema, outdir, includes_dir):
                 if len(att.split("|")) > 1:
                     ns,att = att.split("|")
                 atttype, atttypename = vrv_getatttype(schema.schema, module, gp, att, includes_dir)
-                docstr = __get_docstr(schema.getattdocs(att), indent=4)
+                docstr = __get_docstr(schema.get_att_desc(att), indent=4)
                 substrings = {
                     "attNameUpper": schema.cc(schema.strpatt(att)),
                     "attNameLower": att,
@@ -641,9 +634,8 @@ def __create_att_classes(schema, outdir, includes_dir):
         }
         
         fullout = CLASSES_HEAD_TEMPLATE.format(**tplvars)
-        fmh = open(os.path.join(outdir, "atts_{0}.h".format(module.lower())), 'w')
-        fmh.write(fullout)
-        fmh.close()
+        fmh = Path(outdir, "atts_{0}.h".format(module.lower()))
+        fmh.write_text(fullout)
         lg.debug("\tCreated atts_{0}.h".format(module.lower()))
         
         
@@ -738,7 +730,7 @@ def __create_att_classes(schema, outdir, includes_dir):
             "elements": classes.strip()
         }
         fullout = CLASSES_IMPL_TEMPLATE.format(**tplvars)
-        fmi = open(os.path.join(outdir, "atts_{0}.cpp".format(module.lower())), 'w')
+        fmi = open(Path(outdir, "atts_{0}.cpp".format(module.lower())), "w")
         fmi.write(fullout)
         fmi.write(SETTERS_IMPL_TEMPLATE_START.format(**tplvars))
         fmi.write(setters)
@@ -753,21 +745,21 @@ def __create_att_classes(schema, outdir, includes_dir):
     ########################################################################### 
     # Classes enum
     ###########################################################################
-    fmi = open(os.path.join(outdir, "attclasses.h".format(module.lower())), 'w')
-    fmi.write(LICENSE)
-    fmi.write(ENUM_GRP_START)
-    fmi.write(enum)
-    fmi.write(ENUM_GRP_END)
-    fmi.close()
+    attclasses = open(Path(outdir, "attclasses.h"), "w")
+    attclasses.write(LICENSE)
+    attclasses.write(ENUM_GRP_START)
+    attclasses.write(enum)
+    attclasses.write(ENUM_GRP_END)
+    attclasses.close()
     lg.debug("\tCreated attclasses.h")
     
     lg.debug("Writing data types and lists")
     ########################################################################### 
-    # Classes enum
+    # Types enum
     ###########################################################################
-    fmi = open(os.path.join(outdir, "atttypes.h".format(module.lower())), 'w')
-    fmi.write(LICENSE)
-    fmi.write(TYPE_GRP_START)
+    atttypes = open(Path(outdir, "atttypes.h"), "w")
+    atttypes.write(LICENSE)
+    atttypes.write(TYPE_GRP_START)
     
     for data_type, values in sorted(schema.data_types.items()):
         if vrv_is_excluded_type(data_type) == True:
@@ -798,7 +790,7 @@ def __create_att_classes(schema, outdir, includes_dir):
             "test": "test"
         }
         vstr += TYPE_END.format(**tpsubstr)
-        fmi.write(vstr)
+        atttypes.write(vstr)
         
     for list_type, values in sorted(schema.data_lists.items()):
         if vrv_is_excluded_type(list_type) == True:
@@ -825,21 +817,21 @@ def __create_att_classes(schema, outdir, includes_dir):
             "val_prefix": val_prefix
         }
         vstr += TYPE_END.format(**tpsubstr)
-        fmi.write(vstr)
+        atttypes.write(vstr)
 
-    fmi.write(TYPE_GRP_END)
+    atttypes.write(TYPE_GRP_END)
     
-    fmi.close()
-    lg.debug("\tCreated atttypes.h".format(module.lower()))
+    atttypes.close()
+    lg.debug("\tCreated atttypes.h")
     
     lg.debug("Writing libmei att converter class")
     ########################################################################### 
     # Classes enum
     ###########################################################################
-    fmi = open(os.path.join(outdir, "attconverter.h".format(module.lower())), 'w')
+    fmi = open(Path(outdir, "attconverter.h"), "w")
     fmi.write(LICENSE)
     fmi.write(CONVERTER_HEADER_TEMPLATE_START)
-    fmi_cpp = open(os.path.join(outdir, "attconverter.cpp".format(module.lower())), 'w')
+    fmi_cpp = open(Path(outdir, "attconverter.cpp"), "w")
     fmi_cpp.write(LICENSE)
     fmi_cpp.write(CONVERTER_IMPL_TEMPLATE_START)
     
@@ -919,32 +911,27 @@ def __create_att_classes(schema, outdir, includes_dir):
     fmi.close()
     fmi_cpp.write(CONVERTER_IMPL_TEMPLATE_END)
     fmi_cpp.close()
-    lg.debug("\tCreated attconverter.h/cpp".format(module.lower()))
+    lg.debug("\tCreated attconverter.h/cpp")
 
-def parse_includes(file_dir, includes_dir):
+def parse_includes(file_dir, includes_dir: str):
+    """Parse includes."""
     lg.debug("Parsing includes")
-
     # get the files in the includes directory
-    includes = [f for f in os.listdir(includes_dir) if not f.startswith(".") and f.endswith(".inc")]
-    # currently unused, see below comment in __copy_codefile
-    # copies = [f for f in os.listdir(includes_dir) if f.endswith(".copy")]
+    includes = [f for f in Path(includes_dir).iterdir()
+                if not f.name.startswith(".")]
 
-    for dp,dn,fn in os.walk(file_dir):
-        for f in fn:
-            if f.startswith("."):
-                continue
-            methods, inc = __process_include(f, includes, includes_dir)
-            if methods:
-                __parse_codefile(methods, inc, dp, f)
+    for f in Path(file_dir).iterdir():
+        if f.name.startswith("."):
+            continue
+        methods, inc = __process_include(f, includes, includes_dir)
+        if methods:
+            __parse_codefile(methods, inc, f.parent, f)
 
-def __process_include(fname, includes, includes_dir):
-    name,ext = os.path.splitext(fname)
+def __process_include(fname, includes, includes_dir: str):
     new_methods, includes_block = None, None
     if "{0}.inc".format(fname) in includes:
         lg.debug("\tProcessing include for {0}".format(fname))
-        f = open(os.path.join(includes_dir, "{0}.inc".format(fname)), 'r')
-        includefile = f.read()
-        f.close()
+        includefile = Path(includes_dir, "{0}.inc".format(fname)).read_text()
         new_methods, includes_block = __parse_includefile(includefile)
         return (new_methods, includes_block)
     else:
@@ -963,9 +950,8 @@ def __parse_includefile(contents):
     return (ret, inc)
 
 def __parse_codefile(methods, includes, directory, codefile):
-    f = open(os.path.join(directory, codefile), 'r')
-    contents = f.readlines()
-    f.close()
+    f = Path(directory, codefile)
+    contents = f.read_text()
     regmatch = re.compile(r"/\* include <(?P<elementName>[^>]+)> \*/")
     incmatch = re.compile(r"/\* #include_block \*/")
     for i,line in enumerate(contents):
@@ -979,10 +965,7 @@ def __parse_codefile(methods, includes, directory, codefile):
             if match.group("elementName") in methods.keys():
                 contents[i] = methods[match.group("elementName")].lstrip("\n")
     
-    f = open(os.path.join(directory, codefile), 'w')
-    f.writelines(contents)
-    f.close()
-    
+    f.write_text(contents)
     
 def __copy_codefile(directory, codefile):  
     # att.h, att_defs.h and att.cpp are required.

--- a/tools/langs/cplusplus_vrv.py
+++ b/tools/langs/cplusplus_vrv.py
@@ -514,22 +514,22 @@ def vrv_getattdefault(schema, module, gp, aname, includes_dir: str = ""):
     if attype == "int":
         if default == None:
             default = "VRV_UNSET"
-        return ("{0}".format(default), "", ["StrToInt", "IntToStr"])
+        return (default, "", ["StrToInt", "IntToStr"])
     elif attype == "char":
         if default == None:
             default = 0
-        return ("{0}".format(default), "", ["StrToInt", "IntToStr"])
+        return (default, "", ["StrToInt", "IntToStr"])
     elif attype == "double":
         if default == None:
             default = 0.0
-        return ("{0}".format(default), "", ["StrToDbl", "DblToStr"])
+        return (default, "", ["StrToDbl", "DblToStr"])
     elif attype == "std::string": 
         return ("\"\"", "", ["StrToStr", "StrToStr"])  
     else:
         if default == None:
             default = vrv_get_type_default(attype)
         cname = vrv_converter_cc(attype)
-        return ("{0}".format(default), "", ["StrTo{0}".format(cname), "{0}ToStr".format(cname)])
+        return (default, "", [f"StrTo{cname}", f"{cname}ToStr"])
 
 def create(schema, outdir, includes_dir = ""):
     lg.debug("Begin Verovio C++ Output ...")

--- a/tools/langs/cplusplus_vrv.py
+++ b/tools/langs/cplusplus_vrv.py
@@ -662,7 +662,6 @@ def __create_att_classes(schema, outdir, includes_dir):
             reads = ""
             writes = ""
             checkers = ""
-            prefix = ""
             setters += SETTERS_IMPL_TEMPLATE_GRP_START.format(**{
                                                               "attGroupNameUpper": schema.cc(schema.strpatt(gp)),
                                                               "attId": "ATT_{0}".format(schema.cc(schema.strpatt(gp)).upper()) })
@@ -682,6 +681,7 @@ def __create_att_classes(schema, outdir, includes_dir):
                     #nsDef = NAMESPACE_TEMPLATE.format(**nssubstr)
                     attrNs = "s, "
                 else:
+                    prefix = ""
                     nsDef = ""
                     attrNs = ""
                 atttype, atttypename = vrv_getatttype(schema.schema, module, gp, att, includes_dir)

--- a/tools/langs/cplusplus_vrv.py
+++ b/tools/langs/cplusplus_vrv.py
@@ -78,7 +78,7 @@ enum AttClassId {
 ENUM_GRP_END = """    ATT_CLASS_max
 };
 
-} // vrv namespace
+} // namespace vrv
 
 #endif // __VRV_ATT_CLASSES_H__
 """
@@ -99,7 +99,7 @@ namespace vrv {
 """
 
 TYPE_GRP_END = """
-} // vrv namespace
+} // namespace vrv
 
 #endif // __VRV_ATT_TYPES_H__
 """
@@ -150,7 +150,7 @@ CONVERTER_HEADER_TEMPLATE = """
 
 CONVERTER_HEADER_TEMPLATE_END = """};
 
-} // vrv namespace
+} // namespace vrv
 
 #endif // __VRV_ATT_CONVERTER_H__
 """
@@ -208,7 +208,7 @@ CONVERTER_IMPL_TEMPLATE_METHOD2_END = """
 """
 
 CONVERTER_IMPL_TEMPLATE_END = """
-} // vrv namespace
+} // namespace vrv
 """
 
 
@@ -263,7 +263,7 @@ GETTERS_IMPL_TEMPLATE_GRP_END = """    }}
 
 GETTERS_IMPL_TEMPLATE_END = """}}
 
-}} // vrv namespace
+}} // namespace vrv
 """
 
 NAMESPACE_TEMPLATE = """MeiNamespace *s = new MeiNamespace("{prefix}", "{href}");\n    """
@@ -305,7 +305,7 @@ namespace vrv {{
 
 {elements}
 
-}} // vrv namespace
+}} // namespace vrv
 
 #endif // __VRV_{moduleNameCaps}_H__
 """

--- a/tools/langs/csharp.py
+++ b/tools/langs/csharp.py
@@ -1,0 +1,398 @@
+# -- coding: utf-8 --
+import logging
+import textwrap
+from pathlib import Path
+
+lg = logging.getLogger('schemaparser')
+
+LANG_NAME = "C#"
+
+NS_PREFIX_MAP = {
+    "http://www.w3.org/XML/1998/namespace": "xml",
+    "http://www.w3.org/1999/xlink": "xlink",
+    "http://www.isocat.org/ns/dcr": "datcat"
+}
+
+AUTHORS = "Anna Plaksin"
+
+ATT_FILE = """using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+{license}
+
+namespace mei
+{{
+    {interfaces}
+
+    {ext_classes}
+}}"""
+
+ATT_METHODS = """#region {attNameLower}
+    {ns_decl}
+    public{static} void Set{attNameUpper}({interfaceParamDefSet}string _val)
+    {{
+      MeiAtt_controller.SetAttribute({interfaceParamInvoke}, {attConst}, _val);
+    }}
+
+    public{static} XAttribute Get{attNameUpper}Attribute({interfaceParamDef})
+    {{
+      return MeiAtt_controller.GetAttribute({interfaceParamInvoke}, {attConst});
+    }}
+    
+    public{static} string Get{attNameUpper}Value({interfaceParamDef})
+    {{
+      return MeiAtt_controller.GetAttributeValue({interfaceParamInvoke}, {attConst});
+    }}
+    
+    public{static} bool Has{attNameUpper}({interfaceParamDef})
+    {{
+      return MeiAtt_controller.HasAttribute({interfaceParamInvoke}, {attConst});
+    }}
+
+    public{static} void Remove{attNameUpper}({interfaceParamDef})
+    {{
+      MeiAtt_controller.RemoveAttribute({interfaceParamInvoke}, {attConst});
+    }}
+    #endregion
+"""
+
+ATTGROUP_EXTENSION_CLASS = """/// <summary>
+  /// Extension methods for {attGroupName}
+  /// </summary>
+  public static class Att{attGroupNameUpper}_extensions
+  {{
+    {methods}
+  }}
+"""
+
+ATTGROUP_INTERFACE = """/// <summary>
+  /// Interface for {attGroupName}
+  /// </summary>
+  public interface IAtt{attGroupNameUpper} : IMEiAtt{members}
+  {{
+
+  }}
+"""
+
+ELEMENT_FILE = """using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+{license}
+
+namespace mei
+{{
+    /// <summary>
+    /// <{elementName}/>
+    /// </summary>
+    public class {elementNameUpper} : MeiElement{attClassInterfaces}
+    {{
+        {constructors}
+
+        {attribute_methods}
+    }}
+}}
+"""
+
+NS_DECLARATION = """private static readonly XNamespace ns_{objectName} = "{ns}";
+"""
+
+ELEMENT_CONSTRUCTORS = """{ns_decl}
+        public {elementNameUpper}() : base({elementConst}) {{ }}
+
+        public {elementNameUpper}(object _content) : base({elementConst}, _content) {{ }}
+
+        public {elementNameUpper}(params object[] _content) : base({elementConst}, _content) {{ }}
+"""
+
+LICENSE = """/////////////////////////////////////////////////////////////////////////////
+// Authors:     Anna Plaksin
+// Created:     2017
+// Copyright (c) Authors and others. All rights reserved.
+//
+// Code generated using a modified version of libmei
+// by Andrew Hankinson, Alastair Porter, and Others
+/////////////////////////////////////////////////////////////////////////////"""
+
+# globals
+TEI_NS = {"tei": "http://www.tei-c.org/ns/1.0",
+          "rng": "http://relaxng.org/ns/structure/1.0"}
+
+
+def windll_getAttClassMembers(schema, group):
+    # returns a list of members of an attribute class
+    memberList = schema.xpath(
+        "//tei:classSpec[@type=$att][@ident=$nm]/tei:classes/tei:memberOf/@key", att="atts", nm=group, namespaces=TEI_NS)
+
+    if "att.id" in memberList:
+        memberList.remove("att.id")
+
+    members = []
+
+    for member in memberList:
+        if member not in members:
+            members.append(member)
+
+    return (members)
+
+
+def windll_getElementNS(schema, element):
+    # returns non-mei namespaces
+    ns = schema.xpath(
+        "//tei:elementSpec[@ident=$el]/@ns", el=element, namespaces=TEI_NS)
+
+    if "http://www.music-encoding.org/ns/mei" in ns:
+        ns.remove("http://www.music-encoding.org/ns/mei")
+
+    return (ns)
+
+
+def windll_writeAttMethods(attribute, atgroup, schema):
+    # writes attribute methods for the defined attribute
+    prefix = ""
+    exp_ns = ""
+    att_name = ""
+    att_const = ""
+    ns_decl = ""
+
+    # check, if attribute is namespaced
+    if len(attribute.split("|")) > 1:
+        ns, attribute = attribute.split("|")
+
+        # check, if namespace is already in prefix list
+        if ns in NS_PREFIX_MAP:
+            prefix = NS_PREFIX_MAP[ns]
+        else:
+            exp_ns = ns
+
+    att_name = "{0}:{1}".format(
+        prefix, attribute) if prefix != "" else "{0}".format(attribute)
+
+    # build readonly for explicit namespaces
+    if exp_ns != "":
+        ns_strings = {
+            "ns": exp_ns,
+            "objectName": att_name,
+        }
+        ns_decl += NS_DECLARATION.format(**ns_strings)
+
+    att_const = "\"{0}\"".format(
+        att_name) if exp_ns == "" else "\"{0}\", ns_{0}".format(att_name)
+
+    # Set interface parameter for an attribute of an attribute class or an element
+    interfaceParamDef = ""
+    interfaceParamInvoke = ""
+    interfaceParamDefSet = ""
+    static = ""
+    if atgroup != "":
+        interfaceParamDef = "this IAtt{0} e".format(
+            schema.cc(schema.strpatt(atgroup)))
+        interfaceParamDefSet = "this IAtt{0} e, ".format(
+            schema.cc(schema.strpatt(atgroup)))
+        interfaceParamInvoke = "e"
+        static = " static"
+    else:
+        interfaceParamDef = ""
+        interfaceParamDefSet = ""
+        interfaceParamInvoke = "this"
+
+    # if att_name == "type":
+    #    att_name = "typeAttribute"
+
+    att_strings = {
+        "ns_decl": ns_decl,
+        "attNameUpper": schema.cc(schema.strpatt(attribute)),
+        "attConst": att_const,
+        "interfaceParamDef": interfaceParamDef,
+        "interfaceParamInvoke": interfaceParamInvoke,
+        "interfaceParamDefSet": interfaceParamDefSet,
+        "attNameLower": att_name,
+        "static": static,
+    }
+
+    att_methods = ATT_METHODS.format(**att_strings)
+
+    return (att_methods)
+
+
+def create(schema, outdir):
+    lg.debug("Begin C# Output ... ")
+    __create_att_classes(schema, outdir)
+    __create_element_classes(schema, outdir)
+
+    lg.debug("Success!")
+
+
+def __get_docstr(text, indent=0):
+    """ Format a docstring. Take the first sentence (. followed by a space)
+        and use it for the brief. Then put the rest of the text after a blank
+        line if there is text there
+    """
+    text = text.strip()
+
+    dotpos = text.find(". ")
+    if dotpos > 0:
+        brief = text[:dotpos+1]
+        content = text[dotpos+2:]
+    else:
+        brief = text
+        content = ""
+    if indent == 0:
+        istr = ""
+    else:
+        istr = "{0:{1}}".format(" ", indent)
+
+    brief = "\n{0} *  ".format(istr).join(textwrap.wrap(brief, 80))
+    content = "\n{0} *  ".format(istr).join(textwrap.wrap(content, 80))
+    docstr = "{0}/** \\brief {1}".format(istr, brief)
+    if len(content) > 0:
+        docstr += "\n{0} * \n{0} *  {1}".format(istr, content)
+    docstr += "\n{0} */".format(istr)
+    return docstr
+
+
+def __create_att_classes(schema, outdir):
+    lg.debug("Creating Attribute Classes")
+
+    outdir_att = Path(outdir, "atts")
+    outdir_att.mkdir()
+
+    for module, atgroup in sorted(schema.attribute_group_structure.items()):
+        fullout = ""
+
+        if not atgroup:
+            # continue if we don't have any attribute groups in this module
+            continue
+
+        for gp, atts in sorted(atgroup.items()):
+
+            extension_classes = ""
+            interfaces = ""
+
+            methods = ""
+
+            gp_members = windll_getAttClassMembers(schema.schema, gp)
+
+            for att in atts:
+                if len(methods) > 0:
+                    methods += "\n    "
+
+                methods += windll_writeAttMethods(att, gp, schema)
+
+            clsubstrings = {
+                "methods": methods,
+                "attGroupNameUpper": schema.cc(schema.strpatt(gp)),
+                "attGroupName": gp,
+            }
+            # add List of members
+            members = ""
+            for member in gp_members:
+                members += ", I{0}".format(schema.cc(member))
+
+            intstrings = {
+                "attGroupNameUpper": schema.cc(schema.strpatt(gp)),
+                "attGroupName": gp,
+                "members": members
+            }
+
+            if methods != "":
+                # if attribute class doesn't contain attributes itself, skip creation of extension class
+                extension_classes += ATTGROUP_EXTENSION_CLASS.format(
+                    **clsubstrings)
+
+            interfaces += ATTGROUP_INTERFACE.format(**intstrings)
+
+            tplvars = {
+                "license": LICENSE.format(authors=AUTHORS),
+                "ext_classes": extension_classes,
+                "interfaces": interfaces
+            }
+
+            fullout = ATT_FILE.format(**tplvars)
+
+            fmh = Path(outdir_att, "att_{0}.cs".format(
+                schema.cc(schema.strpatt(gp)).lower()))
+            fmh.write_text(fullout)
+            lg.debug("\tCreated att_{0}.cs".format(
+                schema.cc(schema.strpatt(gp)).lower()))
+
+
+def __create_element_classes(schema, outdir):
+    lg.debug("Creating Element Classes")
+
+    outdir_el = Path(outdir, "elements")
+    outdir_el.mkdir()
+
+    for module, elements in sorted(schema.element_structure.items()):
+
+        if not elements:
+            continue
+
+        for element, atgroups in sorted(elements.items()):
+            fullout = ""
+            at_interfaces = ""
+            ns_nonmei = ""
+            class_constuctors = ""
+            at_methods = ""
+            interfaces = []
+
+            # Look for attribute classes and attributes within elementSpec
+            for attribute in atgroups:
+                if isinstance(attribute, list):
+                    # self-defined attributes
+                    for sda in attribute:
+                        if len(at_methods) > 0:
+                            at_methods += "\n        "
+                        at_methods += windll_writeAttMethods(sda, "", schema)
+
+                else:
+                    if attribute not in interfaces:
+                        at_interfaces += ", I{0}".format(schema.cc(attribute))
+                        interfaces.append(attribute)
+
+            # Build constructors
+            # First, look for non-mei namespaces
+            ns_nonmei = windll_getElementNS(schema.schema, element)
+            ns_readonly = ""
+            if len(ns_nonmei) > 0:
+                ns_strings = {
+                    "objectName": element,
+                    "ns": ns_nonmei[len(ns_nonmei)-1]
+                }
+                ns_readonly += NS_DECLARATION.format(**ns_strings)
+
+            element_const = "\"{0}\"".format(
+                element) if ns_readonly == "" else "ns_{0}, \"{0}\"".format(element)
+
+            const_strings = {
+                "ns_decl": ns_readonly,
+                "elementConst": element_const,
+                "elementNameUpper": schema.cc(element)
+            }
+
+            class_constuctors += ELEMENT_CONSTRUCTORS.format(**const_strings)
+
+            # In the case of self-defined attributes, implementing IMeiAtt is not necessary,
+            # because used methods of XElement are already available within element class.
+
+            el_docstrings = {
+                "elementName": element,
+                "elementNameUpper": schema.cc(element),
+                "attClassInterfaces": at_interfaces,
+                "constructors": class_constuctors,
+                "attribute_methods": at_methods,
+                "license": LICENSE.format(authors=AUTHORS),
+            }
+
+            fullout += ELEMENT_FILE.format(**el_docstrings)
+
+            fmi = Path(outdir_el, "{0}.cs".format(schema.cc(element)))
+            fmi.write_text(fullout)
+            lg.debug("\tCreated {0}.cs".format(schema.cc(element)))

--- a/tools/langs/html_vrv.py
+++ b/tools/langs/html_vrv.py
@@ -1,62 +1,66 @@
- # -- coding: utf-8 --
+# -- coding: utf-8 --
 
-import os
-import re
-import codecs
-import textwrap
 import logging
-import types
-lg = logging.getLogger('schemaparser')
-import pdb
+from importlib.metadata import PathDistribution
+from pathlib import Path
 
 import yaml
 
-LANG_NAME="HTML"
+lg = logging.getLogger('schemaparser')
+
+
+LANG_NAME = "HTML"
 
 
 def vrv_member_cc(name):
     cc = "".join([n[0].upper() + n[1:] for n in name.split(".")])
     return cc[0].lower() + cc[1:]
-    
+
+
 def vrv_member_cc_upper(name):
     return "".join([n[0].upper() + n[1:] for n in name.split(".")])
+
 
 def vrv_load_config(includes_dir):
     """ Load the vrv attribute overrides into CONFIG."""
     global CONFIG
-    
+
     if not includes_dir:
         0
         return
-        
-    config = os.path.join(includes_dir, "config.yml")
-    if not os.path.isfile(config):
+
+    config = Path(includes_dir, "config.yml")
+    if not config.isfile():
         return
-    
+
     f = open(config, "r")
     CONFIG = yaml.load(f)
     f.close()
-    
+
+
 def vrv_get_att_config(module, att):
-    lg.debug( module )
+    lg.debug(module)
     if not module in CONFIG["modules"] or not att in CONFIG["modules"][module]["attributes"]:
         return None
     return CONFIG["modules"][module]["attributes"][att]
-    
+
+
 def vrv_get_type_config(type):
     if not type in CONFIG["defaults"]:
         return None
     return CONFIG["defaults"][type]
+
 
 def vrv_translatetype(module, att):
     """ Get the type override for an attribute in module."""
     att_config = vrv_get_att_config(module, att)
     if att_config is None:
         return None, ""
-        
+
     att = att_config["type"]
     return (att, "")
-    
+
+
 def vrv_get_att_default(type, module, att):
     """ Get the type default value."""
     # nothing in the defaults
@@ -69,34 +73,38 @@ def vrv_get_att_default(type, module, att):
     # nothing in the module/att
     if att_config is None or "default" not in att_config:
         return type_config["default"]
-       
-    # return the module/att default 
+
+    # return the module/att default
     return att_config["default"]
+
 
 def vrv_translateconverters(type, module, att):
     """ Get the type default converters."""
-    default_converters = ["StrTo{0}".format(vrv_member_cc_upper(att)), "{0}ToStr".format(vrv_member_cc_upper(att))]
+    default_converters = ["StrTo{0}".format(vrv_member_cc_upper(
+        att)), "{0}ToStr".format(vrv_member_cc_upper(att))]
     type_config = vrv_get_type_config(type)
     # nothing in the defaults
     if type_config is None or not "converters" in type_config:
-         return default_converters
+        return default_converters
 
     att_config = vrv_get_att_config(module, att)
     # nothing in the module/att
     if att_config is None or "converters" not in att_config:
         return type_config["converters"]
-       
-    # return the module/att default 
+
+    # return the module/att default
     return att_config["converters"]
 
-def create(schema, outdir, includes_dir = ""):
+
+def create(schema, outdir, includes_dir=""):
     lg.debug("Begin Verovio C++ Output ... ")
-    
+
     vrv_load_config(includes_dir)
-    
+
     __create_att_classes(schema, outdir, includes_dir)
-    
+
     lg.debug("Success!")
+
 
 def __create_att_classes(schema, outdir, includes_dir):
     ###########################################################################
@@ -104,44 +112,44 @@ def __create_att_classes(schema, outdir, includes_dir):
     ###########################################################################
     lg.debug("Creating Doc.")
     enum = ""
-    
+
     c = CONFIG["classes"]
-    
+
     for cc in c:
         lg.debug("\tCreated atts_{0}.h".format(cc))
-    
+
     for module, atgroup in sorted(schema.attribute_group_structure.iteritems()):
         fullout = ""
         classes = ""
         methods = ""
-        
+
         if not atgroup:
             # continue if we don't have any attribute groups in this module
             continue
-        
+
         for gp, atts in sorted(atgroup.iteritems()):
             if not atts:
                 continue
-            
+
             members = ""
             methods = ""
             for att in atts:
                 if len(att.split("|")) > 1:
-                    ns,att = att.split("|")
-                
+                    ns, att = att.split("|")
+
         #fullout = CLASSES_HEAD_TEMPLATE.format(**tplvars)
-        fmh = open(os.path.join(outdir, "atts_{0}.h".format(module.lower())), 'w')
+        fmh = open(Path(outdir, "atts_{0}.h".format(module.lower())), 'w')
         fmh.write(fullout)
         fmh.close()
         lg.debug("\tCreated atts_{0}.h".format(module.lower()))
-        
-    ########################################################################### 
+
+    ###########################################################################
     # Classes enum
     ###########################################################################
-    fmi = open(os.path.join(outdir, "att_classes.h".format(module.lower())), 'w')
-    #fmi.write(LICENSE)
-    #fmi.write(ENUM_GRP_START)
-    #fmi.write(enum)
-    #fmi.write(ENUM_GRP_END)
+    fmi = open(Path(outdir, "att_classes.h".format(module.lower())), 'w')
+    # fmi.write(LICENSE)
+    # fmi.write(ENUM_GRP_START)
+    # fmi.write(enum)
+    # fmi.write(ENUM_GRP_END)
     fmi.close()
     lg.debug("\tCreated atts_{0}.cpp".format(module.lower()))

--- a/tools/langs/html_vrv.py
+++ b/tools/langs/html_vrv.py
@@ -22,7 +22,7 @@ def vrv_member_cc_upper(name):
 
 
 def vrv_load_config(includes_dir):
-    """ Load the vrv attribute overrides into CONFIG."""
+    """Load the vrv attribute overrides into CONFIG."""
     global CONFIG
 
     if not includes_dir:
@@ -30,11 +30,11 @@ def vrv_load_config(includes_dir):
         return
 
     config = Path(includes_dir, "config.yml")
-    if not config.isfile():
+    if not config.is_file():
         return
 
-    f = open(config, "r")
-    CONFIG = yaml.load(f)
+    f = config.open()
+    CONFIG = yaml.load(f, Loader=yaml.FullLoader)
     f.close()
 
 
@@ -118,7 +118,7 @@ def __create_att_classes(schema, outdir, includes_dir):
     for cc in c:
         lg.debug("\tCreated atts_{0}.h".format(cc))
 
-    for module, atgroup in sorted(schema.attribute_group_structure.iteritems()):
+    for module, atgroup in sorted(schema.attribute_group_structure.items()):
         fullout = ""
         classes = ""
         methods = ""
@@ -127,7 +127,7 @@ def __create_att_classes(schema, outdir, includes_dir):
             # continue if we don't have any attribute groups in this module
             continue
 
-        for gp, atts in sorted(atgroup.iteritems()):
+        for gp, atts in sorted(atgroup.items()):
             if not atts:
                 continue
 
@@ -138,18 +138,17 @@ def __create_att_classes(schema, outdir, includes_dir):
                     ns, att = att.split("|")
 
         #fullout = CLASSES_HEAD_TEMPLATE.format(**tplvars)
-        fmh = open(Path(outdir, "atts_{0}.h".format(module.lower())), 'w')
-        fmh.write(fullout)
-        fmh.close()
-        lg.debug("\tCreated atts_{0}.h".format(module.lower()))
+        fmh = Path(outdir, f"atts_{module.lower()}.h")
+        fmh.write_text(fullout)
+        lg.debug(f"\tCreated atts_{module.lower()}.h")
 
     ###########################################################################
     # Classes enum
     ###########################################################################
-    fmi = open(Path(outdir, "att_classes.h".format(module.lower())), 'w')
+    fmi = open(Path(outdir, "att_classes.h"), 'w')
     # fmi.write(LICENSE)
     # fmi.write(ENUM_GRP_START)
     # fmi.write(enum)
     # fmi.write(ENUM_GRP_END)
     fmi.close()
-    lg.debug("\tCreated atts_{0}.cpp".format(module.lower()))
+    lg.debug(f"\tCreated atts_{module.lower()}.cpp")

--- a/tools/langs/java.py
+++ b/tools/langs/java.py
@@ -1,10 +1,10 @@
-import os
-import codecs
-import re
 import logging
+import re
+from pathlib import Path
+
 lg = logging.getLogger('schemaparser')
 
-LANG_NAME="Java"
+LANG_NAME = "Java"
 
 MODULE_TEMPLATE = """{license}
 
@@ -50,6 +50,7 @@ LICENSE = """/*
 
 AUTHORS = "Andrew Hankinson, Alastair Porter, and Others"
 
+
 def create(schema, outdir):
     lg.debug("Begin Java Output...")
 
@@ -57,14 +58,15 @@ def create(schema, outdir):
 
     lg.debug("Success!")
 
+
 def __create_java_classes(schema, outdir):
     lg.debug("Creating Python Modules")
 
-    for module, elements in sorted(schema.element_structure.iteritems()):
+    for module, elements in sorted(schema.element_structure.items()):
         if not elements:
             continue
 
-        for element, atgroups in sorted(elements.iteritems()):
+        for element, atgroups in sorted(elements.items()):
             class_name = capitalize_first_letter(element)
             # Generate the class
             methstr = {
@@ -82,22 +84,22 @@ def __create_java_classes(schema, outdir):
 
             # Save to a file
             file_name = "{0}.java".format(class_name)
-            path = os.path.join(outdir, module.lower())
+            path = Path(outdir, module.lower())
             # Make directory if necessary
-            if not os.path.exists(path):
-                os.makedirs(path)
-            fmi = open(os.path.join(path, file_name), "w")
+            path.mkdir(parents=True, exist_ok=True)
+            fmi = open(Path(path, file_name), "w")
             fmi.write(module_output)
             fmi.close()
             lg.debug("\tCreated {0}".format(file_name, class_name))
 
+
 def __parse_codefile(methods, includes, directory, codefile):
-    f = open(os.path.join(directory, codefile), 'r')
-    contents = f.readlines()
-    f.close()
-    regmatch = re.compile(r"[\s]+# <(?P<elementName>[^>]+)>", re.MULTILINE|re.DOTALL)
+    f = Path(directory, codefile)
+    contents = f.read_text()
+    regmatch = re.compile(
+        r"[\s]+# <(?P<elementName>[^>]+)>", re.MULTILINE | re.DOTALL)
     incmatch = re.compile(r"/\* #include_block \*/")
-    for i,line in enumerate(contents):
+    for i, line in enumerate(contents):
         imatch = re.match(incmatch, line)
         if imatch:
             if includes:
@@ -105,17 +107,17 @@ def __parse_codefile(methods, includes, directory, codefile):
 
         match = re.match(regmatch, line)
         if match:
-            if match.group("elementName") in methods.keys():
-                contents[i] = methods[match.group("elementName")].lstrip("\n") + "\n"
+            if match.group("elementName") in list(methods.keys()):
+                contents[i] = methods[match.group(
+                    "elementName")].lstrip("\n") + "\n"
 
-    f = open(os.path.join(directory, codefile), 'w')
-    f.writelines(contents)
-    f.close()
+    f.write_text(contents)
 
-def capitalize_first_letter(text):
+
+def capitalize_first_letter(string: str) -> str:
     """
     Given a string, capitalize the first letter.
     """
-    chars = list(text.strip())
+    chars = list(string.strip())
     chars[0] = chars[0].upper()
     return "".join(chars)

--- a/tools/langs/python.py
+++ b/tools/langs/python.py
@@ -1,10 +1,10 @@
-import os
-import codecs
-import re
 import logging
+import re
+from pathlib import Path
+
 lg = logging.getLogger('schemaparser')
 
-LANG_NAME="Python"
+LANG_NAME = "Python"
 
 MODULE_TEMPLATE = """
 {license}
@@ -46,6 +46,7 @@ LICENSE = """\"\"\"
 
 AUTHORS = "Andrew Hankinson, Alastair Porter, and Others"
 
+
 def create(schema, outdir):
     lg.debug("Begin Python Output...")
 
@@ -54,88 +55,95 @@ def create(schema, outdir):
 
     lg.debug("Success!")
 
+
 def __create_python_classes(schema, outdir):
+    """Create Python Modules."""
     lg.debug("Creating Python Modules")
 
-    for module, elements in sorted(schema.element_structure.iteritems()):
+    for module, elements in sorted(schema.element_structure.items()):
         if not elements:
             continue
         class_output = ""
         module_output = ""
 
-        for element, atgroups in sorted(elements.iteritems()):
+        for element, atgroups in sorted(elements.items()):
             methstr = {
                 "className": element
             }
             class_output += MODULE_CLASS_TEMPLATE.format(**methstr)
-        
+
         modstr = {
             "classes": class_output,
             "license": LICENSE.format(authors=AUTHORS),
         }
         module_output = MODULE_TEMPLATE.format(**modstr)
 
-        fmi = open(os.path.join(outdir, "{0}.py".format(module.lower())), "w")
-        fmi.write(module_output)
-        fmi.close()
+        fmi = Path(outdir, "{0}.py".format(module.lower()))
+        fmi.write_text(module_output)
         lg.debug("\tCreated {0}.py".format(module.lower()))
 
+
 def __create_init(schema, outdir):
+    """Create init file."""
     m = []
     a = []
-    p = open(os.path.join(outdir, "__init__.py"), 'w')
-    for module, elements in sorted(schema.element_structure.iteritems()):
+    p = Path(outdir, "__init__.py")
+    for module, elements in sorted(schema.element_structure.items()):
         a.append('"{0}"'.format(module.lower()))
         m.append("from pymei.Modules.{0} import *\n".format(module.lower()))
-    p.write("__all__ = [{0}]\n\n".format(", ".join(a)))
-    p.writelines(m)
-    p.close()
+    init_string = "__all__ = [{0}]\n\n".format(", ".join(a)) + "".join(m)
+    p.write_text(init_string)
 
-def parse_includes(file_dir, includes_dir):
+
+def parse_includes(file_dir, includes_dir: str):
+    """Parse includes."""
     lg.debug("Parsing includes")
     # get the files in the includes directory
-    includes = [f for f in os.listdir(includes_dir) if not f.startswith(".")]
+    includes = [f for f in Path(includes_dir).iterdir()
+                if not f.name.startswith(".")]
 
-    for dp,dn,fn in os.walk(file_dir):
-        for f in fn:
-            if f.startswith("."):
-                continue
-            methods, inc = __process_include(f, includes, includes_dir)
-            if methods:
-                __parse_codefile(methods, inc, dp, f)
+    for f in Path(file_dir).iterdir():
+        if f.name.startswith("."):
+            continue
+        methods, inc = __process_include(f, includes, includes_dir)
+        if methods:
+            __parse_codefile(methods, inc, f.parent, f)
 
-def __process_include(fname, includes, includes_dir):
-    name,ext = os.path.splitext(fname)
+
+def __process_include(fname, includes, includes_dir: str):
+    """Process the include file for our methods."""
     new_methods, includes_block = None, None
     if "{0}.inc".format(fname) in includes:
         lg.debug("\tProcessing include for {0}".format(fname))
-        f = open(os.path.join(includes_dir, "{0}.inc".format(fname)), 'r')
-        includefile = f.read()
-        f.close()
+        includefile = Path(includes_dir, "{0}.inc".format(fname)).read_text()
         new_methods, includes_block = __parse_includefile(includefile)
         return (new_methods, includes_block)
     else:
         return (None, None)
 
+
 def __parse_includefile(contents):
-    # parse the include file for our methods.
+    """Parse the include file for our methods."""
     ret = {}
     inc = []
-    reg = re.compile(r"# <(?P<elementName>[^>]+)>(.+?)# </(?P=elementName)>", re.MULTILINE|re.DOTALL)
+    reg = re.compile(
+        r"# <(?P<elementName>[^>]+)>(.+?)# </(?P=elementName)>", re.MULTILINE | re.DOTALL)
     ret = dict(re.findall(reg, contents))
 
     # grab the include for the includes...
-    reginc = re.compile(r"/\* #include_block \*/(.+?)/\* #include_block \*/", re.MULTILINE|re.DOTALL)
+    reginc = re.compile(
+        r"/\* #include_block \*/(.+?)/\* #include_block \*/", re.MULTILINE | re.DOTALL)
     inc = re.findall(reginc, contents)
     return (ret, inc)
 
+
 def __parse_codefile(methods, includes, directory, codefile):
-    f = open(os.path.join(directory, codefile), 'r')
-    contents = f.readlines()
-    f.close()
-    regmatch = re.compile(r"[\s]+# <(?P<elementName>[^>]+)>", re.MULTILINE|re.DOTALL)
+    f = Path(directory, codefile)
+    contents = f.read_text()
+    regmatch = re.compile(
+        r"[\s]+# <(?P<elementName>[^>]+)>", re.MULTILINE | re.DOTALL)
     incmatch = re.compile(r"/\* #include_block \*/")
-    for i,line in enumerate(contents):
+    for i, line in enumerate(contents):
         imatch = re.match(incmatch, line)
         if imatch:
             if includes:
@@ -143,17 +151,8 @@ def __parse_codefile(methods, includes, directory, codefile):
 
         match = re.match(regmatch, line)
         if match:
-            if match.group("elementName") in methods.keys():
-                contents[i] = methods[match.group("elementName")].lstrip("\n") + "\n"
-    
-    f = open(os.path.join(directory, codefile), 'w')
-    f.writelines(contents)
-    f.close()
+            if match.group("elementName") in list(methods.keys()):
+                contents[i] = methods[match.group(
+                    "elementName")].lstrip("\n") + "\n"
 
-
-
-
-
-
-
-
+    f.write_text(contents)

--- a/tools/langs/python.py
+++ b/tools/langs/python.py
@@ -78,9 +78,9 @@ def __create_python_classes(schema, outdir):
         }
         module_output = MODULE_TEMPLATE.format(**modstr)
 
-        fmi = Path(outdir, "{0}.py".format(module.lower()))
+        fmi = Path(outdir, f"{module.lower()}.py")
         fmi.write_text(module_output)
-        lg.debug("\tCreated {0}.py".format(module.lower()))
+        lg.debug(f"\tCreated {module.lower()}.py")
 
 
 def __create_init(schema, outdir):
@@ -90,7 +90,7 @@ def __create_init(schema, outdir):
     p = Path(outdir, "__init__.py")
     for module, elements in sorted(schema.element_structure.items()):
         a.append('"{0}"'.format(module.lower()))
-        m.append("from pymei.Modules.{0} import *\n".format(module.lower()))
+        m.append(f"from pymei.Modules.{module.lower()} import *\n")
     init_string = "__all__ = [{0}]\n\n".format(", ".join(a)) + "".join(m)
     p.write_text(init_string)
 
@@ -113,9 +113,9 @@ def parse_includes(file_dir, includes_dir: str):
 def __process_include(fname, includes, includes_dir: str):
     """Process the include file for our methods."""
     new_methods, includes_block = None, None
-    if "{0}.inc".format(fname) in includes:
-        lg.debug("\tProcessing include for {0}".format(fname))
-        includefile = Path(includes_dir, "{0}.inc".format(fname)).read_text()
+    if (fname + ".inc") in includes:
+        lg.debug(f"\tProcessing include for {fname}")
+        includefile = Path(includes_dir, {fname}).with_suffix(".inc").read_text()
         new_methods, includes_block = __parse_includefile(includefile)
         return (new_methods, includes_block)
     else:

--- a/tools/parseschema2.py
+++ b/tools/parseschema2.py
@@ -1,6 +1,6 @@
 # -- coding: utf-8 --
 
-# Copyright (c) 2011-2015 Andrew Hankinson, Alastair Porter, and Others
+# Copyright (c) 2011-2022 Andrew Hankinson, Alastair Porter, and Others
 
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -22,19 +22,25 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import sys
-if sys.version_info < (2, 7):
-    raise Exception("requires python 2.7")
+
+if sys.version_info < (3, 4):
+    raise Exception("requires python 3.4")
+
+import codecs
+import logging
+import re
+import shutil
+from argparse import ArgumentParser
+from pathlib import Path
+from typing import List
 
 from lxml import etree
-import os
-import shutil
-import codecs
-import re
-from argparse import ArgumentParser
-import logging
+
+from langs import AVAILABLE_LANGS
 
 lg = logging.getLogger('schemaparser')
-f = logging.Formatter("%(levelname)s %(asctime)s On Line: %(lineno)d %(message)s")
+f = logging.Formatter(
+    "%(levelname)s %(asctime)s On Line: %(lineno)d %(message)s")
 h = logging.StreamHandler()
 h.setFormatter(f)
 
@@ -43,7 +49,8 @@ lg.addHandler(h)
 
 # globals
 TEI_NS = {"tei": "http://www.tei-c.org/ns/1.0"}
-TEI_RNG_NS = {"tei": "http://www.tei-c.org/ns/1.0", "rng": "http://relaxng.org/ns/structure/1.0"}
+TEI_RNG_NS = {"tei": "http://www.tei-c.org/ns/1.0",
+              "rng": "http://relaxng.org/ns/structure/1.0"}
 NAMESPACES = {'xml': 'http://www.w3.org/XML/1998/namespace',
               'xlink': 'http://www.w3.org/1999/xlink'}
 
@@ -57,7 +64,8 @@ class MeiSchema(object):
         self.active_modules = []  # the modules active in the resulting output
         self.element_structure = {}  # the element structure.
         self.attribute_group_structure = {}  # the attribute group structure
-        self.inverse_attribute_group_structure = {}  # inverted, so we can map attgroups to modules
+        # inverted, so we can map attgroups to modules
+        self.inverse_attribute_group_structure = {}
         # holding data types and data lists
         self.data_types = {}
         self.data_lists = {}
@@ -67,12 +75,13 @@ class MeiSchema(object):
         self.get_data_types_and_lists()
         self.invert_attribute_group_structure()
         self.set_active_modules()
-        
-        #lg.debug(self.data_lists)
 
+        # lg.debug(self.data_lists)
 
     def get_elements(self):
-        elements = [m for m in self.schema.xpath("//tei:elementSpec", namespaces=TEI_NS)]
+        """Retrieves all defined elements from the schema."""
+        elements = [m for m in self.schema.xpath(
+            "//tei:elementSpec", namespaces=TEI_NS)]
         for element in elements:
             modname = element.get("module").split(".")[-1]
 
@@ -82,7 +91,8 @@ class MeiSchema(object):
             element_name = element.get("ident")
             memberships = []
 
-            element_membership = element.xpath("./tei:classes/tei:memberOf", namespaces=TEI_NS)
+            element_membership = element.xpath(
+                "./tei:classes/tei:memberOf", namespaces=TEI_NS)
             for member in element_membership:
                 if member.get("key").split(".")[0] != "att":
                     # skip the models that this element might be a member of
@@ -94,7 +104,8 @@ class MeiSchema(object):
 
             # need a way to keep self-defined attributes:
             selfattributes = []
-            attdefs = element.xpath("./tei:attList/tei:attDef", namespaces=TEI_NS)
+            attdefs = element.xpath(
+                "./tei:attList/tei:attDef", namespaces=TEI_NS)
             if attdefs:
                 for attdef in attdefs:
                     if attdef.get("ident") == "id":
@@ -102,10 +113,13 @@ class MeiSchema(object):
                     attname = self.__process_att(attdef)
                     selfattributes.append(attname)
 
-                self.element_structure[modname][element_name].append(selfattributes)
+                self.element_structure[modname][element_name].append(
+                    selfattributes)
 
     def get_attribute_groups(self):
-        attribute_groups = [m for m in self.schema.xpath("//tei:classSpec[@type=$at]", at="atts", namespaces=TEI_NS)]
+        """Retrieves all defined attribute classes from the schema."""
+        attribute_groups = [m for m in self.schema.xpath(
+            "//tei:classSpec[@type=$at]", at="atts", namespaces=TEI_NS)]
         for group in attribute_groups:
             group_name = group.get("ident")
 
@@ -113,7 +127,8 @@ class MeiSchema(object):
                 continue
 
             group_module = group.get("module").split(".")[-1]
-            attdefs = group.xpath("./tei:attList/tei:attDef", namespaces=TEI_NS)
+            attdefs = group.xpath(
+                "./tei:attList/tei:attDef", namespaces=TEI_NS)
             if not attdefs:
                 continue
 
@@ -125,71 +140,84 @@ class MeiSchema(object):
                 if attdef.get("ident") == "id":
                     continue
                 attname = self.__process_att(attdef)
-                self.attribute_group_structure[group_module][group_name].append(attname)
-                
+                self.attribute_group_structure[group_module][group_name].append(
+                    attname)
+
     def get_data_types_and_lists(self):
 
-        compoundalternate = [m for m in self.schema.xpath("//tei:macroSpec[@type=\"dt\" and .//tei:alternate[@minOccurs=\"1\" and @maxOccurs=\"1\"]]", namespaces=TEI_RNG_NS)]
+        compoundalternate = [m for m in self.schema.xpath(
+            "//tei:macroSpec[@type=\"dt\" and .//tei:alternate[@minOccurs=\"1\" and @maxOccurs=\"1\"]]", namespaces=TEI_RNG_NS)]
         for ct in compoundalternate:
             #lg.debug("TYPE - {0}".format(ct.get("ident")))
             data_type = ct.get("ident")
             self.data_types[data_type] = []
-            subtypes = [m for m in ct.xpath(".//tei:alternate/tei:macroRef", namespaces=TEI_RNG_NS)]
+            subtypes = [m for m in ct.xpath(
+                ".//tei:alternate/tei:macroRef", namespaces=TEI_RNG_NS)]
             for st in subtypes:
                 #lg.debug("SUBTYPE - {0}".format(st.get("name")))
-                subtype = st.xpath("//tei:macroSpec[@ident=\"{0}\"]//tei:valList/tei:valItem".format(st.get("key")), namespaces=TEI_RNG_NS)
+                subtype = st.xpath("//tei:macroSpec[@ident=\"{0}\"]//tei:valList/tei:valItem".format(
+                    st.get("key")), namespaces=TEI_RNG_NS)
                 for v in subtype:
-                    #lg.debug("\t{0}".format(v.get("ident")))
+                    # lg.debug("\t{0}".format(v.get("ident")))
                     type_value = v.get("ident")
                     self.data_types[data_type].append(type_value)
             if len(self.data_types[data_type]) == 0:
                 del self.data_types[data_type]
                 #lg.debug("REMOVE {0}".format(data_type))
-        
-        compoundchoice = [m for m in self.schema.xpath("//tei:macroSpec[@type=\"dt\" and .//rng:choice]", namespaces=TEI_RNG_NS)]
+
+        compoundchoice = [m for m in self.schema.xpath(
+            "//tei:macroSpec[@type=\"dt\" and .//rng:choice]|//tei:dataSpec[.//rng:choice]", namespaces=TEI_RNG_NS)]
         for ct in compoundchoice:
             #lg.debug("TYPE - {0}".format(ct.get("ident")))
             data_type = ct.get("ident")
             self.data_types[data_type] = []
-            subtypes = [m for m in ct.xpath(".//rng:choice/rng:ref", namespaces=TEI_RNG_NS)]
+            subtypes = [m for m in ct.xpath(
+                ".//rng:choice/rng:ref", namespaces=TEI_RNG_NS)]
             for st in subtypes:
                 #lg.debug("SUBTYPE - {0}".format(st.get("name")))
-                subtype = st.xpath("//tei:macroSpec[@ident=\"{0}\"]//tei:valList/tei:valItem".format(st.get("name")), namespaces=TEI_RNG_NS)
+                subtype = st.xpath("//tei:macroSpec[@ident=\"{0}\"]//tei:valList/tei:valItem|//tei:dataSpec[@ident=\"{0}\"]//tei:valList/tei:valItem".format(
+                    st.get("name")), namespaces=TEI_RNG_NS)
                 for v in subtype:
-                    #lg.debug("\t{0}".format(v.get("ident")))
+                    # lg.debug("\t{0}".format(v.get("ident")))
                     type_value = v.get("ident")
                     self.data_types[data_type].append(type_value)
             if len(self.data_types[data_type]) == 0:
                 del self.data_types[data_type]
                 #lg.debug("REMOVE {0}".format(data_type))
-        
-        types = [m for m in self.schema.xpath("//tei:macroSpec[.//tei:valList[@type=\"closed\" or @type=\"semi\"]]", namespaces=TEI_RNG_NS)]
+
+        types = [m for m in self.schema.xpath(
+            "//tei:macroSpec[.//tei:valList[@type=\"closed\" or @type=\"semi\"]]|//tei:dataSpec[.//tei:valList[@type=\"closed\" or @type=\"semi\"]]", namespaces=TEI_RNG_NS)]
         for t in types:
             #lg.debug("TYPE - {0}".format(t.get("ident")))
             data_type = t.get("ident")
             self.data_types[data_type] = []
-            values = t.xpath(".//tei:valList/tei:valItem", namespaces=TEI_RNG_NS)
+            values = t.xpath(".//tei:valList/tei:valItem",
+                             namespaces=TEI_RNG_NS)
             for v in values:
-                #lg.debug("\t{0}".format(v.get("ident")))
+                # lg.debug("\t{0}".format(v.get("ident")))
                 type_value = v.get("ident")
                 self.data_types[data_type].append(type_value)
-        
-        vallists = [m for m in self.schema.xpath("//tei:valList[@type=\"closed\" or @type=\"semi\"]", namespaces=TEI_RNG_NS)]
+
+        vallists = [m for m in self.schema.xpath(
+            "//tei:valList[@type=\"closed\" or @type=\"semi\"]", namespaces=TEI_RNG_NS)]
         for vl in vallists:
-            element = vl.xpath("./ancestor::tei:classSpec", namespaces=TEI_RNG_NS)
-            attName = vl.xpath("./parent::tei:attDef/@ident", namespaces=TEI_RNG_NS)
-            #if ($current.valList/ancestor::tei:classSpec) then($current.valList/ancestor::tei:classSpec/@ident) else($current.valList/ancestor::tei:elementSpec/@ident
+            element = vl.xpath("./ancestor::tei:classSpec",
+                               namespaces=TEI_RNG_NS)
+            attName = vl.xpath("./parent::tei:attDef/@ident",
+                               namespaces=TEI_RNG_NS)
+            # if ($current.valList/ancestor::tei:classSpec) then($current.valList/ancestor::tei:classSpec/@ident) else($current.valList/ancestor::tei:elementSpec/@ident
             if element:
                 #lg.debug("VALLIST - ELEMEMT {0} --- {1}".format(element[0].get("ident"),attName[0]))
-                data_list = "{0}@{1}".format(element[0].get("ident"),attName[0])
+                data_list = "{0}@{1}".format(
+                    element[0].get("ident"), attName[0])
                 self.data_lists[data_list] = []
                 self.data_lists[data_list]
                 values = vl.xpath(".//tei:valItem", namespaces=TEI_RNG_NS)
                 for v in values:
-                    #lg.debug("\t{0}".format(v.get("ident")))
+                    # lg.debug("\t{0}".format(v.get("ident")))
                     list_value = v.get("ident")
                     self.data_lists[data_list].append(list_value)
-            #elif attName:
+            # elif attName:
             #    elName = vl.xpath("./ancestor::tei:elementSpec/@ident", namespaces=TEI_RNG_NS)
             #    lg.debug("VALLIST {0} --- {1}".format(elName[0],attName[0]))
             #    data_list = "{0}.{1}".format(elName[0],attName[0])
@@ -200,7 +228,6 @@ class MeiSchema(object):
             #        list_value = v.get("ident")
             #        self.data_lists[data_list].append(list_value)
 
-
     def invert_attribute_group_structure(self):
         for module, groups in self.attribute_group_structure.items():
             for attgroup in groups:
@@ -210,7 +237,8 @@ class MeiSchema(object):
         self.active_modules = list(self.element_structure.keys())
         self.active_modules.sort()
 
-    def __process_att(self, attdef):
+    def __process_att(self, attdef: etree.Element) -> str:
+        """Process attribute definition."""
         attname = ""
         attdefident = attdef.get("ident")
         if "-" in attdefident:
@@ -227,8 +255,10 @@ class MeiSchema(object):
 
         return attname
 
-    def __get_membership(self, member, resarr):
-        member_attgroup = member.xpath("//tei:classSpec[@type=$att][@ident=$nm]", att="atts", nm=member.get("key"), namespaces=TEI_NS)
+    def __get_membership(self, member: etree.Element, resarr: List[str]) -> None:
+        """Get attribute groups."""
+        member_attgroup = member.xpath(
+            "//tei:classSpec[@type=$att][@ident=$nm]", att="atts", nm=member.get("key"), namespaces=TEI_NS)
 
         if member_attgroup:
             member_attgroup = member_attgroup[0]
@@ -239,51 +269,62 @@ class MeiSchema(object):
             if member_attgroup.get("ident") == "att.id":
                 return
             resarr.append(member_attgroup.get("ident"))
-        m2s = member_attgroup.xpath("./tei:classes/tei:memberOf", namespaces=TEI_NS)
-
-        if not m2s:
-            return
+        m2s = member_attgroup.xpath(
+            "./tei:classes/tei:memberOf", namespaces=TEI_NS)
 
         for mship in m2s:
             self.__get_membership(mship, resarr)
 
-    def strpatt(self, name):
-        """ Returns a version of the string with any leading att. stripped. """
-        return name.replace("att.", "")
+    def strpatt(self, string: str) -> str:
+        """Returns a version of the string with any leading att. stripped."""
+        return string.replace("att.", "")
 
-    def strpdot(self, name):
-        return "".join([n for n in name.split(".")])
+    def strpdot(self, string: str) -> str:
+        """Returns a version of the string without any dots."""
+        return "".join([n for n in string.split(".")])
 
-    def cc(self, name):
-        """ Returns a CamelCasedName version of attribute.case.names.
-        """
-        return "".join([n[0].upper() + n[1:] for n in name.split(".")])
+    def cc(self, att_name: str) -> str:
+        """Returns a CamelCasedName version of attribute.case.names."""
+        return "".join([n[0].upper() + n[1:] for n in att_name.split(".")])
 
-    def getattdocs(self, aname):
-        """ returns the documentation string for element name, or an empty string if there is none."""
-        dsc = self.schema.xpath("//tei:attDef[@ident=$name]/tei:desc/text()", name=aname, namespaces=TEI_NS)
-        if dsc:
-            return re.sub('[\s\t]+', ' ', dsc[0])  # strip extraneous whitespace
+    def get_att_desc(self, att_name: str) -> str:
+        """Returns the documentation string for an attribute by name."""
+        desc = self.schema.find(
+            f"//tei:attDef[@ident='{att_name}']/tei:desc", namespaces=TEI_NS)
+        if desc is not None:
+            # strip extraneous whitespace
+            return re.sub('[\s\t]+', ' ', desc.xpath("string()"))
         else:
             return ""
 
-    def geteldocs(self, ename):
-        dsc = self.schema.xpath("//tei:elementSpec[@ident=$name]/tei:desc/text()", name=ename, namespaces=TEI_NS)
-        if dsc:
-            return re.sub('[\s\t]+', ' ', dsc[0])  # strip extraneous whitespace
+    def get_elem_desc(self, elem_name: str) -> str:
+        """Returns the documentation string for an element by name."""
+        desc = self.schema.find(
+            f"//tei:elementSpec[@ident='{elem_name}']/tei:desc", namespaces=TEI_NS)
+        if desc is not None:
+            # strip extraneous whitespace
+            return re.sub('[\s\t]+', ' ', desc.xpath("string()"))
         else:
             return ""
 
 
 if __name__ == "__main__":
-    p = ArgumentParser(usage='%(prog)s [compiled | -sl] [-h] [-o OUTDIR] [-i INCLUDES] [-d] [-l [LANG [LANG ...]]]') #Custom usage message to show user [compiled] should go before all other flags 
+    # Custom usage message to show user [compiled] should go before all other flags
+    p = ArgumentParser(
+        usage='%(prog)s [compiled | -sl] [-h] [-o OUTDIR] [-i INCLUDES] [-d] [-l [LANG [LANG ...]]]')
     exclusive_group = p.add_mutually_exclusive_group()
-    exclusive_group.add_argument("compiled", help="A compiled ODD file", nargs="?") # Due to nargs="?", "compiled" will appear as optional and not positional
+    # Due to nargs="?", "compiled" will appear as optional and not positional
+    exclusive_group.add_argument(
+        "compiled", help="A compiled ODD file", nargs="?")
     p.add_argument("-o", "--outdir", default="output", help="output directory")
-    p.add_argument("-l", "--lang", default=["python"], help="Programming language or languages to output. To output multiple languages at once, list desired languages separated by a space after -l. For example: python parseschema2.py [compiled] -l python cpp", nargs="*")
-    p.add_argument("-i", "--includes", help="Parse external includes from a given directory")
-    p.add_argument("-d", "--debugging", help="Run with verbose output", action="store_true")
-    exclusive_group.add_argument("-sl", "--showlang", help="Show languages and exit.", action="store_true")
+    p.add_argument("-l", "--lang", default=[
+                   "python"], help="Programming language or languages to output. To output multiple languages at once, list desired languages separated by a space after -l. For example: python parseschema2.py [compiled] -l python cpp", nargs="*")
+    p.add_argument("-i", "--includes",
+                   help="Parse external includes from a given directory")
+    p.add_argument("-d", "--debugging",
+                   help="Run with verbose output", action="store_true")
+    exclusive_group.add_argument(
+        "-sl", "--showlang", help="Show available languages and exit.", action="store_true")
 
     args = p.parse_args()
 
@@ -292,100 +333,105 @@ if __name__ == "__main__":
         print("error: You must include a compiled ODD file")
         sys.exit(1)
 
-    avail_langs = ["cpp", "python", "manuscript", "vrv"]
-    
     if not args.lang == "python":
-        for l_langs in args.lang:
-            if l_langs.lower() not in avail_langs:
+        for lang in args.lang:
+            if lang.lower() not in AVAILABLE_LANGS:
                 p.print_usage()
-                print("error: One or more of the languages you have chosen are not supported. To check supported languages use the -sl flag")
+                print("Error: One or more of the languages you have chosen are not supported. To check supported languages use the -sl flag")
                 sys.exit(1)
 
     if args.showlang:
-        import langs
         print("Available Output Languages")
-        for l in langs.AVAILABLE_LANGS:
+        for l in AVAILABLE_LANGS:
             print("\t{0}".format(l))
         sys.exit(0)
 
-    compiled_odd = args.compiled
+    compiled_odd = Path(args.compiled)
 
     mei_source = codecs.open(compiled_odd, 'r', 'utf-8')
     # sf = codecs.open(args.source,'r', "utf-8")
     # cf = codecs.open(args.customization, 'r', "utf-8")
-    outdir = args.outdir
+    outdir = Path(args.outdir)
 
-    if not os.path.exists(args.outdir):
-        os.mkdir(args.outdir)
+    outdir.mkdir(exist_ok=True)
 
     schema = MeiSchema(mei_source)
 
-    for l_langs in args.lang:
-        if "cpp" in l_langs.lower():
+    for lang in args.lang:
+        if "cpp" in lang.lower():
             import langs.cplusplus as cpp
-            output_directory = os.path.join(outdir, "cpp")
-            if os.path.exists(output_directory):
+            output_directory = Path(outdir, "cpp")
+            if output_directory.exists():
                 lg.debug("Removing old C++ output directory")
                 shutil.rmtree(output_directory)
-            os.mkdir(output_directory)
+            output_directory.mkdir()
             cpp.create(schema, output_directory)
             if args.includes:
                 cpp.parse_includes(output_directory, args.includes)
 
-    if "vrv" in args.lang:
-        import langs.cplusplus_vrv as vrv
-        output_directory = os.path.join(outdir, "libmei")
-        if os.path.exists(output_directory):
-            lg.debug("Removing old Verovio C++ output directory")
-            shutil.rmtree(output_directory)
-        os.mkdir(output_directory)
-        
-        if args.includes:
+        if "csharp" in lang.lower():
+            import langs.csharp as csharp
+            output_directory = Path(outdir, "c-sharp")
+            if output_directory.exists():
+                lg.debug("Removing old C# output directory")
+                shutil.rmtree(output_directory)
+            output_directory.mkdir()
+            csharp.create(schema, output_directory)
+            if args.includes:
+                csharp.parse_includes(output_directory, args.includes)
+
+        if "java" in lang.lower():
+            import langs.java as java
+            output_directory = Path(outdir, "java")
+            if output_directory.exists():
+                lg.debug("Removing old Java output directory")
+                shutil.rmtree(output_directory)
+            output_directory.mkdir()
+            java.create(schema, output_directory)
+            if args.includes:
+                java.parse_includes(output_directory, args.includes)
+
+        if "manuscript" in lang.lower():
+            import langs.manuscript as ms
+            output_directory = Path(outdir, "manuscript")
+            if output_directory.exists():
+                lg.debug("Removing old Manuscript output directory")
+                shutil.rmtree(output_directory)
+            output_directory.mkdir()
+            ms.create(schema, output_directory)
+
+        if "python" in lang.lower():
+            import langs.python as py
+            output_directory = Path(outdir, "python")
+            if output_directory.exists():
+                lg.debug("Removing old Python output directory")
+                shutil.rmtree(output_directory)
+            output_directory.mkdir()
+            py.create(schema, output_directory)
+            if args.includes:
+                py.parse_includes(output_directory, args.includes)
+
+        if "vrv" in lang.lower():
+            import langs.cplusplus_vrv as vrv
+            output_directory = Path(outdir, "libmei")
+            if output_directory.exists():
+                lg.debug("Removing old Verovio C++ output directory")
+                shutil.rmtree(output_directory)
+            output_directory.mkdir()
+            if args.includes:
+                vrv.create(schema, output_directory, args.includes)
+                vrv.parse_includes(output_directory, args.includes)
+            else:
+                vrv.create(schema, output_directory)
+
+        if "vdoc" in lang.lower():
+            import langs.html_vrv as vrv
+            output_directory = Path(outdir, "doc")
+            if output_directory.exists():
+                lg.debug("Removing old Verovio C++ output directory")
+                shutil.rmtree(output_directory)
+            output_directory.mkdir()
             vrv.create(schema, output_directory, args.includes)
-            vrv.parse_includes(output_directory, args.includes)
-        else:
-            vrv.create(schema, output_directory)
-            
-    if "vdoc" in args.lang:
-        import langs.html_vrv as vrv
-        output_directory = os.path.join(outdir, "doc")
-        if os.path.exists(output_directory):
-            lg.debug("Removing old Verovio C++ output directory")
-            shutil.rmtree(output_directory)
-        os.mkdir(output_directory)
-        
-        vrv.create(schema, output_directory, args.includes)
-
-    if "python" in l_langs.lower():
-        import langs.python as py
-        output_directory = os.path.join(outdir, "python")
-        if os.path.exists(output_directory):
-            lg.debug("Removing old Python output directory")
-            shutil.rmtree(output_directory)
-        os.mkdir(output_directory)
-        py.create(schema, output_directory)
-        if args.includes:
-            py.parse_includes(output_directory, args.includes)
-
-    if "manuscript" in l_langs.lower():
-        import langs.manuscript as ms
-        output_directory = os.path.join(outdir, "manuscript")
-        if os.path.exists(output_directory):
-            lg.debug("Removing old Manuscript output directory")
-            shutil.rmtree(output_directory)
-        os.mkdir(output_directory)
-        ms.create(schema, output_directory)
-
-    if "java" in args.lang:
-        import langs.java as java
-        output_directory = os.path.join(outdir, "java")
-        if os.path.exists(output_directory):
-            lg.debug("Removing old Java output directory")
-            shutil.rmtree(output_directory)
-        os.mkdir(output_directory)
-        java.create(schema, output_directory)
-        if args.includes:
-            java.parse_includes(output_directory, args.includes)
 
     mei_source.close()
 

--- a/tools/parseschema2.py
+++ b/tools/parseschema2.py
@@ -243,15 +243,15 @@ class MeiSchema(object):
         attdefident = attdef.get("ident")
         if "-" in attdefident:
             f, l = attdefident.split("-")
-            attdefident = "{0}{1}".format(f, l.title())
+            attdefident = f"{f}{l.title()}"
 
         if attdef.get("ns"):
-            attname = "{0}|{1}".format(attdef.get("ns"), attdefident)
+            attname = f"{attdef.get('ns')}|{attdefident}"
         elif ":" in attdefident:
             pfx, att = attdefident.split(":")
-            attname = "{0}|{1}".format(NAMESPACES[pfx], att)
+            attname = f"{NAMESPACES[pfx]}|{att}"
         else:
-            attname = "{0}".format(attdefident)
+            attname = f"{attdefident}"
 
         return attname
 
@@ -293,7 +293,7 @@ class MeiSchema(object):
             f"//tei:attDef[@ident='{att_name}']/tei:desc", namespaces=TEI_NS)
         if desc is not None:
             # strip extraneous whitespace
-            return re.sub('[\s\t]+', ' ', desc.xpath("string()"))
+            return re.sub("[\s\t]+", " ", desc.xpath("string()"))
         else:
             return ""
 
@@ -303,7 +303,7 @@ class MeiSchema(object):
             f"//tei:elementSpec[@ident='{elem_name}']/tei:desc", namespaces=TEI_NS)
         if desc is not None:
             # strip extraneous whitespace
-            return re.sub('[\s\t]+', ' ', desc.xpath("string()"))
+            return re.sub("[\s\t]+", " ", desc.xpath("string()"))
         else:
             return ""
 
@@ -343,7 +343,7 @@ if __name__ == "__main__":
     if args.showlang:
         print("Available Output Languages")
         for l in AVAILABLE_LANGS:
-            print("\t{0}".format(l))
+            print(f"\t{l}")
         sys.exit(0)
 
     compiled_odd = Path(args.compiled)

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,0 +1,2 @@
+pyyaml
+lxml


### PR DESCRIPTION
This PR presents a major update to the tools. It collects all latests developments (e.g., for C# and Manuscript) and brings:

* drops Python 2 support
* switches from `os.path` to `pathlib` (simplifying several things)
* sorting imports (PEP 8)
* formatting (PEP 8) and adding docstrings
* adds a `requirements.txt`

Most important for Verovio context:
For retrieving `tei:desc` it switches from `text()` to `string()` importing the complete description instead only the first chuck to a subelement. 
