### PR TITLE
Remove att.surface

### DIFF
--- a/mei/develop/mei-verovio.xml
+++ b/mei/develop/mei-verovio.xml
@@ -84,47 +84,47 @@
 				<moduleRef key="MEI.frettab"/>
 
 				<classSpec ident="att.meiVersion" module="MEI.shared" type="atts" mode="replace">
-                    <desc xml:lang="en">Attributes that record the version of MEI supported.</desc>
-                    <attList>
-                        <attDef ident="meiversion" usage="req">
-                            <desc xml:lang="en">Specifies a generic MEI version label.</desc>
+					<desc xml:lang="en">Attributes that record the version of MEI supported.</desc>
+					<attList>
+						<attDef ident="meiversion" usage="req">
+							<desc xml:lang="en">Specifies a generic MEI version label.</desc>
 							<defaultVal>5.0.0-dev</defaultVal>
 							<valList type="closed">
-							  <valItem ident="2013">
-								<desc xml:lang="en">MEI 2013</desc>
-							  </valItem>
-							  <valItem ident="3.0.0">
-								<desc xml:lang="en">MEI 3.0.0</desc>
-							  </valItem>
-							  <valItem ident="4.0.0">
-								<desc xml:lang="en">MEI 4.0.0</desc>
-							  </valItem>
-							  <valItem ident="4.0.1">
-								<desc xml:lang="en">MEI 4.0.1</desc>
-							  </valItem>
-							  <valItem ident="5.0.0-dev+basic">
-								<desc xml:lang="en">MEI basic</desc>
-							  </valItem>
-							  <valItem ident="5.0.0-dev">
-								<desc xml:lang="en">Development version of MEI 5.0.0</desc>
-							  </valItem>
+								<valItem ident="2013">
+									<desc xml:lang="en">MEI 2013</desc>
+								</valItem>
+								<valItem ident="3.0.0">
+									<desc xml:lang="en">MEI 3.0.0</desc>
+								</valItem>
+								<valItem ident="4.0.0">
+									<desc xml:lang="en">MEI 4.0.0</desc>
+								</valItem>
+								<valItem ident="4.0.1">
+									<desc xml:lang="en">MEI 4.0.1</desc>
+								</valItem>
+								<valItem ident="5.0.0-dev+basic">
+									<desc xml:lang="en">MEI basic</desc>
+								</valItem>
+								<valItem ident="5.0.0-dev">
+									<desc xml:lang="en">Development version of MEI 5.0.0</desc>
+								</valItem>
 							</valList>
 						</attDef>
-                    </attList>
-                </classSpec>
-		  
-			   <!-- ****************************************************************** -->
+					</attList>
+				</classSpec>
+
+				<!-- ****************************************************************** -->
 				<!-- Page-based MEI -->
-			   <!-- ****************************************************************** -->
-						   
+				<!-- ****************************************************************** -->
+
 				<moduleSpec ident="MEI.pageBased" mode="add">
 					<desc/>
 				</moduleSpec>
-				
+
 				<classSpec ident="model.pagesLike" type="model" module="MEI.pageBased" mode="add">
 					<desc xml:lang="en">Collects pagesLike elements.</desc>
 				</classSpec>
-				
+
 				<elementSpec ident="pages" module="MEI.pageBased" mode="add">
 					<desc xml:lang="en">A set of pages in a page-based encoding</desc>
 					<classes>
@@ -137,19 +137,19 @@
 						</rng:zeroOrMore>
 					</content>
 				</elementSpec>
-				
+
 				<classSpec ident="model.pageLike" type="model" module="MEI.pageBased" mode="add">
 					<desc xml:lang="en">Collects pageLike elements.</desc>
 				</classSpec>
-				
+
 				<elementSpec ident="page" module="MEI.pageBased" mode="add">
 					<desc xml:lang="en">A page in a page-base encoding</desc>
 					<classes>
-						<memberOf key="att.pages"/>
-						<!-- was: att.scoreDef.vis -->
 						<memberOf key="att.common"/>
-						<memberOf key="att.pageRef"/>
-						<memberOf key="att.surface"/>
+						<memberOf key="att.dimensions"/>
+						<!--<memberOf key="att.pageRef"/>-->
+						<memberOf key="att.facsimile"/>
+						<memberOf key="att.margins"/>
 						<memberOf key="model.pageLike"/>
 					</classes>
 					<content>
@@ -165,7 +165,7 @@
 						</rng:zeroOrMore>
 					</content>
 				</elementSpec>
-				
+
 				<!-- remove att.pages and att.systems from att.scoreDef.vis, 
 					as they go on other elements now -->
 				<!--<classSpec ident="att.scoreDef.vis" module="MEI.visual" type="atts" mode="change">
@@ -175,7 +175,7 @@
 					<memberOf key="att.systems" mode="delete"/>
 					</classes>
 					</classSpec>-->
-				
+
 				<elementSpec ident="body" module="MEI.shared" mode="change">
 					<content>
 						<rng:oneOrMore>
@@ -193,13 +193,13 @@
 						<sch:assert role="warning" test="@*[starts-with(local-name(),'system.')]">System-related attributes should go on a system element.</sch:assert>                                
 						</sch:rule>
 						</constraint>
-						</constraintSpec>       --> 
+						</constraintSpec>       -->
 				</elementSpec>
-				
+
 				<classSpec ident="model.systemLike" type="model" module="MEI.pageBased" mode="add">
 					<desc xml:lang="en">Collects systemLike elements.</desc>
 				</classSpec>
-				
+
 				<elementSpec ident="system" module="MEI.pageBased" mode="add">
 					<desc xml:lang="en">A system in a page-based encoding</desc>
 					<classes>
@@ -226,11 +226,11 @@
 						</rng:zeroOrMore>
 					</content>
 				</elementSpec>
-				
+
 				<classSpec ident="model.secbLike" type="model" module="MEI.pageBased" mode="add">
 					<desc xml:lang="en">Collects secbLike (section beginning) elements.</desc>
 				</classSpec>
-				
+
 				<!-- because the hierarchy is flipped, &lt;section&gt; has to become a milestone -->
 				<elementSpec ident="secb" module="MEI.pageBased" mode="add">
 					<gloss xml:lang="en">section beginning</gloss>
@@ -243,11 +243,11 @@
 						<rng:empty/>
 					</content>
 				</elementSpec>
-				
+
 				<classSpec ident="model.mdivbLike" type="model" module="MEI.pageBased" mode="add">
 					<desc xml:lang="en">Collects mdivbLike (mdiv beginning) elements.</desc>
 				</classSpec>
-				
+
 				<elementSpec ident="mdivb" module="MEI.pageBased" mode="add">
 					<gloss xml:lang="en">mdiv beginning</gloss>
 					<desc xml:lang="en">A milestone element indicating the start of a new mdiv in page-based MEI.</desc>
@@ -259,11 +259,11 @@
 						<rng:empty/>
 					</content>
 				</elementSpec>
-				
+
 				<classSpec ident="model.scorebLike" type="model" module="MEI.pageBased" mode="add">
 					<desc xml:lang="en">Collects scorebLike (score beginning) elements.</desc>
 				</classSpec>
-				
+
 				<elementSpec ident="scoreb" module="MEI.pageBased" mode="add">
 					<gloss xml:lang="en">score beginning</gloss>
 					<desc xml:lang="en">A milestone element indicating the start of a new score in page-based MEI.</desc>
@@ -280,11 +280,11 @@
 						<p>This element is necessary to allow round-tripping between page-based and score-based (regular) MEI.</p>
 					</remarks>
 				</elementSpec>
-				
+
 				<classSpec ident="model.partsbLike" type="model" module="MEI.pageBased" mode="add">
 					<desc xml:lang="en">Collects partsbLike (parts beginning) elements.</desc>
 				</classSpec>
-				
+
 				<elementSpec ident="partsb" module="MEI.pageBased" mode="add">
 					<gloss xml:lang="en">parts beginning</gloss>
 					<desc xml:lang="en">A milestone element indicating the start of new parts in page-based MEI.</desc>
@@ -299,11 +299,11 @@
 						<p>This element is necessary to allow round-tripping between page-based and score-based (regular) MEI.</p>
 					</remarks>
 				</elementSpec>
-				
+
 				<classSpec ident="model.partbLike" type="model" module="MEI.pageBased" mode="add">
 					<desc xml:lang="en">Collects partbLike (part beginning) elements.</desc>
 				</classSpec>
-				
+
 				<elementSpec ident="partb" module="MEI.pageBased" mode="add">
 					<gloss xml:lang="en">part beginning</gloss>
 					<desc xml:lang="en">A milestone element indicating the start of a new part in page-based MEI.</desc>
@@ -320,11 +320,11 @@
 						<p>This element is necessary to allow round-tripping between page-based and score-based (regular) MEI.</p>
 					</remarks>
 				</elementSpec>
-				
+
 				<classSpec ident="model.milestoneLike" type="model" module="MEI.ptrref" mode="add">
 					<desc xml:lang="en">Collects milestone like elements.</desc>
 				</classSpec>
-				
+
 				<elementSpec ident="milestone" module="MEI.ptrref" mode="add">
 					<gloss xml:lang="en">milestone</gloss>
 					<desc xml:lang="en">A generic milestone element that can be used as anchor in an MEI file.</desc>
@@ -339,7 +339,7 @@
 						<empty/>
 					</content>
 				</elementSpec>
-				
+
 				<elementSpec ident="milestoneEnd" module="MEI.ptrref" mode="add">
 					<gloss xml:lang="en">milestone end</gloss>
 					<desc xml:lang="en">A milestone element that can be used to indicate the end of an arbitrary feature in MEI.</desc>
@@ -357,15 +357,15 @@
 					<constraintSpec ident="check_milestoneEnd" scheme="isoschematron">
 						<constraint>
 							<sch:rule context="mei:milestoneEnd">
-								<sch:assert role="error" test="exists(@startid)">milestoneEnd needs a @startid attribute.</sch:assert>                                                                
+								<sch:assert role="error" test="exists(@startid)">milestoneEnd needs a @startid attribute.</sch:assert>
 							</sch:rule>
 						</constraint>
-					</constraintSpec>        
+					</constraintSpec>
 					<remarks>
 						<p>The @startid attribute should be used to point to the element starting the feature that is ended by an milestoneEnd.</p>
 					</remarks>
 				</elementSpec>
-				
+
 				<classSpec ident="att.coord.x1" module="MEI.shared" type="atts">
 					<desc xml:lang="en">Attributes that record the x coordinate of the left side of a feature.</desc>
 					<attList>
@@ -418,7 +418,7 @@
 						</attDef>
 					</attList>
 				</classSpec>
-				
+
 				<classSpec ident="att.coord.lr" module="MEI.shared" type="atts">
 					<desc xml:lang="en">Attributes for left/right coordinates.</desc>
 					<classes>
@@ -426,25 +426,25 @@
 						<memberOf key="att.coord.x2"/>
 					</classes>
 				</classSpec>
-				
+
 				<elementSpec ident="measure" module="MEI.cmn" mode="change">
 					<classes mode="change">
 						<memberOf key="att.coord.lr" mode="add"/>
 					</classes>
 				</elementSpec>
-				
+
 				<elementSpec ident="staff" module="MEI.shared" mode="change">
 					<classes mode="change">
 						<memberOf key="att.coord.y1" mode="add"/>
 					</classes>
 				</elementSpec>
-				
+
 				<classSpec ident="att.xy" module="MEI.shared" type="atts" mode="change">
 					<classes mode="change">
 						<memberOf key="att.coord.x1"/>
 					</classes>
 				</classSpec>
-				
+
 				<!-- Making att.facsimile a member of att.coordinated -->
 				<!-- is this necessary? -->
 				<!--<classSpec ident="att.facsimile" module="MEI.facsimile" type="atts" mode="change">
@@ -453,10 +453,40 @@
 					<memberOf key="att.coordinated" mode="add"/>
 					</classes>
 					</classSpec>-->
-				
-				
+
+
 				<!-- todos down here -->
-				
+
+				<classSpec ident="att.margins" module="MEI.pageBased" type="atts" mode="add">
+					<desc xml:lang="en">Attribute that define margins of a page.</desc>
+					<attList org="group">
+						<attDef ident="topmar" usage="opt">
+							<desc>Indicates the amount of whitespace at the top of a page.</desc>
+							<datatype maxOccurs="1" minOccurs="1">
+								<rng:ref name="data.MEASUREMENTABS"/>
+							</datatype>
+						</attDef>
+						<attDef ident="botmar" usage="opt">
+							<desc>Indicates the amount of whitespace at the bottom of a page.</desc>
+							<datatype maxOccurs="1" minOccurs="1">
+								<rng:ref name="data.MEASUREMENTABS"/>
+							</datatype>
+						</attDef>
+						<attDef ident="leftmar" usage="opt">
+							<desc>Indicates the amount of whitespace at the left side of a page.</desc>
+							<datatype maxOccurs="1" minOccurs="1">
+								<rng:ref name="data.MEASUREMENTABS"/>
+							</datatype>
+						</attDef>
+						<attDef ident="rightmar" usage="opt">
+							<desc>Indicates the amount of whitespace at the right side of a page.</desc>
+							<datatype maxOccurs="1" minOccurs="1">
+								<rng:ref name="data.MEASUREMENTABS"/>
+							</datatype>
+						</attDef>
+					</attList>
+				</classSpec>
+
 				<classSpec ident="att.surface" module="MEI.pageBased" type="atts" mode="add">
 					<desc xml:lang="en">This attribute is used to point to a surface.</desc>
 					<attList>
@@ -468,11 +498,11 @@
 						</attDef>
 					</attList>
 				</classSpec>
-			  
-			  <!-- ****************************************************************** -->
+
+				<!-- ****************************************************************** -->
 				<!-- Tablature MEI -->
-			  <!-- ****************************************************************** -->
-			   
+				<!-- ****************************************************************** -->
+
 				<moduleSpec ident="MEI.frettab" mode="add">
 					<desc/>
 				</moduleSpec>
@@ -485,32 +515,32 @@
 				<dataSpec ident="data.COURSETUNING" module="MEI.frettab">
 					<desc xml:lang="en">Standard course tunings.</desc>
 					<content>
-					   <valList type="semi">
-					      <valItem ident="guitar.standard">
-					         <desc xml:lang="en">Standard tuning for current guitars. The courses are tuned to E2 A2 D3 G3 B3 E4.</desc>
-					      </valItem>
-					      <valItem ident="guitar.drop.D">
-					         <desc xml:lang="en">Drop D tuning for guitars. The lowest course is tuned down to D, while all other courses are kept to their regular pitches. D2 A2 D3 G3 B3 E4.</desc>
-					      </valItem>
-					      <valItem ident="guitar.open.D">
-					         <desc xml:lang="en">Open D tuning for guitars. D2 A2 D3 F3s A3 D4.</desc>
-					      </valItem>
-					      <valItem ident="guitar.open.G">
-					         <desc xml:lang="en">Open G tuning for guitars. D2 G2 D2 G2 B3 D4.</desc>
-					      </valItem>
-					      <valItem ident="guitar.open.A">
-					         <desc xml:lang="en">Open A tuning for guitars. E2 A2 E3 A3 C4s E4.</desc>
-					      </valItem>
-					      <valItem ident="lute.renaissance.6">
-					         <desc xml:lang="en">Renaissance tuning for lutes with 10 strings on 6 courses. G2G3 C3C4 F3F4 A4A4 D4 G4.</desc>
-					      </valItem>
-					      <valItem ident="lute.baroque.d.major">
-					         <desc xml:lang="en">Baroque tuning for lutes with 6 stable courses, and additional bass courses tuned to the key of D Major.</desc>
-					      </valItem>
-					   	<valItem ident="lute.baroque.d.minor">
-					   		<desc xml:lang="en">Baroque tuning for lutes with 6 stable courses, and additional bass courses tuned to the key of D minor.</desc>
-					   	</valItem>
-					   </valList>
+						<valList type="semi">
+							<valItem ident="guitar.standard">
+								<desc xml:lang="en">Standard tuning for current guitars. The courses are tuned to E2 A2 D3 G3 B3 E4.</desc>
+							</valItem>
+							<valItem ident="guitar.drop.D">
+								<desc xml:lang="en">Drop D tuning for guitars. The lowest course is tuned down to D, while all other courses are kept to their regular pitches. D2 A2 D3 G3 B3 E4.</desc>
+							</valItem>
+							<valItem ident="guitar.open.D">
+								<desc xml:lang="en">Open D tuning for guitars. D2 A2 D3 F3s A3 D4.</desc>
+							</valItem>
+							<valItem ident="guitar.open.G">
+								<desc xml:lang="en">Open G tuning for guitars. D2 G2 D2 G2 B3 D4.</desc>
+							</valItem>
+							<valItem ident="guitar.open.A">
+								<desc xml:lang="en">Open A tuning for guitars. E2 A2 E3 A3 C4s E4.</desc>
+							</valItem>
+							<valItem ident="lute.renaissance.6">
+								<desc xml:lang="en">Renaissance tuning for lutes with 10 strings on 6 courses. G2G3 C3C4 F3F4 A4A4 D4 G4.</desc>
+							</valItem>
+							<valItem ident="lute.baroque.d.major">
+								<desc xml:lang="en">Baroque tuning for lutes with 6 stable courses, and additional bass courses tuned to the key of D Major.</desc>
+							</valItem>
+							<valItem ident="lute.baroque.d.minor">
+								<desc xml:lang="en">Baroque tuning for lutes with 6 stable courses, and additional bass courses tuned to the key of D minor.</desc>
+							</valItem>
+						</valList>
 					</content>
 				</dataSpec>
 				<dataSpec ident="data.NOTATIONTYPE" module="MEI" mode="replace">
@@ -552,7 +582,7 @@
 						</valList>
 					</content>
 				</dataSpec>
-				
+
 				<classSpec ident="att.note.ges.tab" module="MEI.frettab" type="atts" mode="add">
 					<attList>
 						<attDef ident="tab.course" usage="opt" mode="add">

--- a/mei/develop/mei-verovio.xml
+++ b/mei/develop/mei-verovio.xml
@@ -150,9 +150,9 @@
 					<classes>
 						<memberOf key="att.common"/>
 						<memberOf key="att.dimensions"/>
-						<!--<memberOf key="att.pageRef"/>-->
 						<memberOf key="att.facsimile"/>
 						<memberOf key="att.margins"/>
+						<!--<memberOf key="att.pageRef"/>-->
 						<memberOf key="model.pageLike"/>
 					</classes>
 					<content>
@@ -464,27 +464,31 @@
 					<desc xml:lang="en">Attribute that define margins of a page.</desc>
 					<attList org="group">
 						<attDef ident="topmar" usage="opt">
-							<desc>Indicates the amount of whitespace at the top of a page.</desc>
+							<gloss xml:lang="en">top margin</gloss>
+							<desc xml:lang="en">Indicates the amount of whitespace at the top of a page.</desc>
 							<datatype maxOccurs="1" minOccurs="1">
-								<rng:ref name="data.MEASUREMENTABS"/>
+								<dataRef key="data.MEASUREMENTUNSIGNED"/>
 							</datatype>
 						</attDef>
 						<attDef ident="botmar" usage="opt">
-							<desc>Indicates the amount of whitespace at the bottom of a page.</desc>
+							<gloss xml:lang="en">bottom margin</gloss>
+							<desc xml:lang="en">Indicates the amount of whitespace at the bottom of a page.</desc>
 							<datatype maxOccurs="1" minOccurs="1">
-								<rng:ref name="data.MEASUREMENTABS"/>
+								<dataRef key="data.MEASUREMENTUNSIGNED"/>
 							</datatype>
 						</attDef>
 						<attDef ident="leftmar" usage="opt">
-							<desc>Indicates the amount of whitespace at the left side of a page.</desc>
+							<gloss xml:lang="en">left margin</gloss>
+							<desc xml:lang="en">Indicates the amount of whitespace at the left side of a page.</desc>
 							<datatype maxOccurs="1" minOccurs="1">
-								<rng:ref name="data.MEASUREMENTABS"/>
+								<dataRef key="data.MEASUREMENTUNSIGNED"/>
 							</datatype>
 						</attDef>
 						<attDef ident="rightmar" usage="opt">
-							<desc>Indicates the amount of whitespace at the right side of a page.</desc>
+							<gloss xml:lang="en">right margin</gloss>
+							<desc xml:lang="en">Indicates the amount of whitespace at the right side of a page.</desc>
 							<datatype maxOccurs="1" minOccurs="1">
-								<rng:ref name="data.MEASUREMENTABS"/>
+								<dataRef key="data.MEASUREMENTUNSIGNED"/>
 							</datatype>
 						</attDef>
 					</attList>

--- a/mei/develop/mei-verovio.xml
+++ b/mei/develop/mei-verovio.xml
@@ -145,11 +145,11 @@
 				<elementSpec ident="page" module="MEI.pageBased" mode="add">
 					<desc xml:lang="en">A page in a page-base encoding</desc>
 					<classes>
+						<memberOf key="att.pages"/>
 						<!-- was: att.scoreDef.vis -->
 						<memberOf key="att.common"/>
-						<memberOf key="att.facsimile"/>
-						<!-- <memberOf key="att.pageRef"/> -->
-						<memberOf key="att.pages"/>
+						<memberOf key="att.pageRef"/>
+						<memberOf key="att.surface"/>
 						<memberOf key="model.pageLike"/>
 					</classes>
 					<content>
@@ -456,7 +456,19 @@
 				
 				
 				<!-- todos down here -->
-
+				
+				<classSpec ident="att.surface" module="MEI.pageBased" type="atts" mode="add">
+					<desc xml:lang="en">This attribute is used to point to a surface.</desc>
+					<attList>
+						<attDef ident="surface" usage="opt">
+							<desc xml:lang="en">contains a reference to a surface element</desc>
+							<datatype>
+								<dataRef key="data.URI"/>
+							</datatype>
+						</attDef>
+					</attList>
+				</classSpec>
+			  
 			  <!-- ****************************************************************** -->
 				<!-- Tablature MEI -->
 			  <!-- ****************************************************************** -->

--- a/mei/develop/mei-verovio.xml
+++ b/mei/develop/mei-verovio.xml
@@ -145,11 +145,11 @@
 				<elementSpec ident="page" module="MEI.pageBased" mode="add">
 					<desc xml:lang="en">A page in a page-base encoding</desc>
 					<classes>
-						<memberOf key="att.pages"/>
 						<!-- was: att.scoreDef.vis -->
 						<memberOf key="att.common"/>
-						<memberOf key="att.pageRef"/>
-						<memberOf key="att.surface"/>
+						<memberOf key="att.facsimile"/>
+						<!-- <memberOf key="att.pageRef"/> -->
+						<memberOf key="att.pages"/>
 						<memberOf key="model.pageLike"/>
 					</classes>
 					<content>
@@ -456,19 +456,7 @@
 				
 				
 				<!-- todos down here -->
-				
-				<classSpec ident="att.surface" module="MEI.pageBased" type="atts" mode="add">
-					<desc xml:lang="en">This attribute is used to point to a surface.</desc>
-					<attList>
-						<attDef ident="surface" usage="opt">
-							<desc xml:lang="en">contains a reference to a surface element</desc>
-							<datatype>
-								<dataRef key="data.URI"/>
-							</datatype>
-						</attDef>
-					</attList>
-				</classSpec>
-			  
+
 			  <!-- ****************************************************************** -->
 				<!-- Tablature MEI -->
 			  <!-- ****************************************************************** -->

--- a/mei/develop/mei-verovio.xml
+++ b/mei/develop/mei-verovio.xml
@@ -23,23 +23,26 @@
 			</sourceDesc>
 		</fileDesc>
 		<revisionDesc>
-			<change n="5" when="2022-10-26">
-				<desc xml:lang="en">Moved to PureODD</desc>
+			<change n="5" when="2022-11-08" resp="#KR">
+				<desc xml:lang="en">Added att.margins.</desc>
+			</change>
+			<change n="5" when="2022-10-26" resp="#KR">
+				<desc xml:lang="en">Moved to PureODD.</desc>
 			</change>
 			<change n="4" when="2022-07-15">
-				<desc xml:lang="en">Add all supported versions of MEI</desc>
+				<desc xml:lang="en">Add all supported versions of MEI.</desc>
 			</change>
 			<change n="4" when="2021-03-30">
-				<desc xml:lang="en">Include tablature preliminary proposal</desc>
+				<desc xml:lang="en">Include tablature preliminary proposal.</desc>
 			</change>
 			<change n="3" when="2013-11-08">
-				<desc xml:lang="en">Changing to /measure/staff organisation; adding /pages container in /mdiv; adding /page@position; changing scb to secb; </desc>
+				<desc xml:lang="en">Changing to /measure/staff organisation; adding /pages container in /mdiv; adding /page@position; changing scb to secb.</desc>
 			</change>
 			<change n="2" when="2013-09-08">
-				<desc xml:lang="en">Adding /staff/measure organisation and other fixes</desc>
+				<desc xml:lang="en">Adding /staff/measure organisation and other fixes.</desc>
 			</change>
 			<change n="2" when="2013-09-02">
-				<desc xml:lang="en">Fixing naming according to MEI convention and other small fixes</desc>
+				<desc xml:lang="en">Fixing naming according to MEI convention and other small fixes.</desc>
 			</change>
 			<change n="1" when="2013-08-29">
 				<desc xml:lang="en">Initial setup of the customization.</desc>

--- a/mei/develop/mei-verovio_compiled.odd
+++ b/mei/develop/mei-verovio_compiled.odd
@@ -19,23 +19,26 @@
 			</sourceDesc>
 		</fileDesc>
 		<revisionDesc>
-			<change n="5" when="2022-10-26">
-				<desc xml:lang="en">Moved to PureODD</desc>
+			<change n="5" when="2022-11-08" resp="#KR">
+				<desc xml:lang="en">Added att.margins.</desc>
+			</change>
+			<change n="5" when="2022-10-26" resp="#KR">
+				<desc xml:lang="en">Moved to PureODD.</desc>
 			</change>
 			<change n="4" when="2022-07-15">
-				<desc xml:lang="en">Add all supported versions of MEI</desc>
+				<desc xml:lang="en">Add all supported versions of MEI.</desc>
 			</change>
 			<change n="4" when="2021-03-30">
-				<desc xml:lang="en">Include tablature preliminary proposal</desc>
+				<desc xml:lang="en">Include tablature preliminary proposal.</desc>
 			</change>
 			<change n="3" when="2013-11-08">
-				<desc xml:lang="en">Changing to /measure/staff organisation; adding /pages container in /mdiv; adding /page@position; changing scb to secb; </desc>
+				<desc xml:lang="en">Changing to /measure/staff organisation; adding /pages container in /mdiv; adding /page@position; changing scb to secb.</desc>
 			</change>
 			<change n="2" when="2013-09-08">
-				<desc xml:lang="en">Adding /staff/measure organisation and other fixes</desc>
+				<desc xml:lang="en">Adding /staff/measure organisation and other fixes.</desc>
 			</change>
 			<change n="2" when="2013-09-02">
-				<desc xml:lang="en">Fixing naming according to MEI convention and other small fixes</desc>
+				<desc xml:lang="en">Fixing naming according to MEI convention and other small fixes.</desc>
 			</change>
 			<change n="1" when="2013-08-29">
 				<desc xml:lang="en">Initial setup of the customization.</desc>
@@ -13224,34 +13227,34 @@
       </attDef>
     </attList>
   </classSpec><classSpec ident="att.meiVersion" module="MEI.shared" type="atts" mode="replace">
-                    <desc xml:lang="en">Attributes that record the version of MEI supported.</desc>
-                    <attList>
-                        <attDef ident="meiversion" usage="req">
-                            <desc xml:lang="en">Specifies a generic MEI version label.</desc>
+					<desc xml:lang="en">Attributes that record the version of MEI supported.</desc>
+					<attList>
+						<attDef ident="meiversion" usage="req">
+							<desc xml:lang="en">Specifies a generic MEI version label.</desc>
 							<defaultVal>5.0.0-dev</defaultVal>
 							<valList type="closed">
-							  <valItem ident="2013">
-								<desc xml:lang="en">MEI 2013</desc>
-							  </valItem>
-							  <valItem ident="3.0.0">
-								<desc xml:lang="en">MEI 3.0.0</desc>
-							  </valItem>
-							  <valItem ident="4.0.0">
-								<desc xml:lang="en">MEI 4.0.0</desc>
-							  </valItem>
-							  <valItem ident="4.0.1">
-								<desc xml:lang="en">MEI 4.0.1</desc>
-							  </valItem>
-							  <valItem ident="5.0.0-dev+basic">
-								<desc xml:lang="en">MEI basic</desc>
-							  </valItem>
-							  <valItem ident="5.0.0-dev">
-								<desc xml:lang="en">Development version of MEI 5.0.0</desc>
-							  </valItem>
+								<valItem ident="2013">
+									<desc xml:lang="en">MEI 2013</desc>
+								</valItem>
+								<valItem ident="3.0.0">
+									<desc xml:lang="en">MEI 3.0.0</desc>
+								</valItem>
+								<valItem ident="4.0.0">
+									<desc xml:lang="en">MEI 4.0.0</desc>
+								</valItem>
+								<valItem ident="4.0.1">
+									<desc xml:lang="en">MEI 4.0.1</desc>
+								</valItem>
+								<valItem ident="5.0.0-dev+basic">
+									<desc xml:lang="en">MEI basic</desc>
+								</valItem>
+								<valItem ident="5.0.0-dev">
+									<desc xml:lang="en">Development version of MEI 5.0.0</desc>
+								</valItem>
 							</valList>
 						</attDef>
-                    </attList>
-                </classSpec><classSpec rend="add" ident="att.mensur.log" module="MEI.shared" type="atts">
+					</attList>
+				</classSpec><classSpec rend="add" ident="att.mensur.log" module="MEI.shared" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <memberOf key="att.duration.ratio"/>
@@ -20086,11 +20089,11 @@
 					</content></elementSpec><classSpec rend="add" predeclare="true" ident="model.pageLike" type="model" module="MEI.pageBased" mode="add">
 					<desc xml:lang="en">Collects pageLike elements.</desc>
 				</classSpec><elementSpec rend="add" ident="page" module="MEI.pageBased" mode="add"><desc xml:lang="en">A page in a page-base encoding</desc><classes>
-						
 						<memberOf key="att.common"/>
+						<memberOf key="att.dimensions"/>
 						<memberOf key="att.facsimile"/>
+						<memberOf key="att.margins"/>
 						
-						<memberOf key="att.pages"/>
 						<memberOf key="model.pageLike"/>
 					</classes><content>
 						<zeroOrMore xmlns="http://relaxng.org/ns/structure/1.0"><choice><ref name="model.systemLike"/><ref name="model.milestoneLike"/><ref name="model.secbLike"/><ref name="model.mdivbLike"/><ref name="model.scoreLike"/><ref name="model.partsLike"/></choice></zeroOrMore>
@@ -20161,7 +20164,7 @@
 					</content><constraintSpec ident="check_milestoneEnd" scheme="isoschematron">
 						<constraint>
 							<sch:rule context="mei:milestoneEnd">
-								<sch:assert role="error" test="exists(@startid)">milestoneEnd needs a @startid attribute.</sch:assert>                                                                
+								<sch:assert role="error" test="exists(@startid)">milestoneEnd needs a @startid attribute.</sch:assert>
 							</sch:rule>
 						</constraint>
 					</constraintSpec><remarks>
@@ -20208,6 +20211,38 @@
 						<memberOf key="att.coord.x1"/>
 						<memberOf key="att.coord.x2"/>
 					</classes>
+				</classSpec><classSpec rend="add" ident="att.margins" module="MEI.pageBased" type="atts" mode="add">
+					<desc xml:lang="en">Attribute that define margins of a page.</desc>
+					<attList org="group">
+						<attDef ident="topmar" usage="opt">
+							<gloss xml:lang="en">top margin</gloss>
+							<desc xml:lang="en">Indicates the amount of whitespace at the top of a page.</desc>
+							<datatype maxOccurs="1" minOccurs="1">
+								<dataRef key="data.MEASUREMENTUNSIGNED"/>
+							</datatype>
+						</attDef>
+						<attDef ident="botmar" usage="opt">
+							<gloss xml:lang="en">bottom margin</gloss>
+							<desc xml:lang="en">Indicates the amount of whitespace at the bottom of a page.</desc>
+							<datatype maxOccurs="1" minOccurs="1">
+								<dataRef key="data.MEASUREMENTUNSIGNED"/>
+							</datatype>
+						</attDef>
+						<attDef ident="leftmar" usage="opt">
+							<gloss xml:lang="en">left margin</gloss>
+							<desc xml:lang="en">Indicates the amount of whitespace at the left side of a page.</desc>
+							<datatype maxOccurs="1" minOccurs="1">
+								<dataRef key="data.MEASUREMENTUNSIGNED"/>
+							</datatype>
+						</attDef>
+						<attDef ident="rightmar" usage="opt">
+							<gloss xml:lang="en">right margin</gloss>
+							<desc xml:lang="en">Indicates the amount of whitespace at the right side of a page.</desc>
+							<datatype maxOccurs="1" minOccurs="1">
+								<dataRef key="data.MEASUREMENTUNSIGNED"/>
+							</datatype>
+						</attDef>
+					</attList>
 				</classSpec><moduleSpec ident="MEI.frettab" mode="add">
 					<desc/>
 				</moduleSpec><dataSpec rend="add" ident="data.COURSENUMBER" module="MEI.frettab" mode="add">
@@ -20218,32 +20253,32 @@
 				</dataSpec><dataSpec rend="add" ident="data.COURSETUNING" module="MEI.frettab">
 					<desc xml:lang="en">Standard course tunings.</desc>
 					<content>
-					   <valList type="semi">
-					      <valItem ident="guitar.standard">
-					         <desc xml:lang="en">Standard tuning for current guitars. The courses are tuned to E2 A2 D3 G3 B3 E4.</desc>
-					      </valItem>
-					      <valItem ident="guitar.drop.D">
-					         <desc xml:lang="en">Drop D tuning for guitars. The lowest course is tuned down to D, while all other courses are kept to their regular pitches. D2 A2 D3 G3 B3 E4.</desc>
-					      </valItem>
-					      <valItem ident="guitar.open.D">
-					         <desc xml:lang="en">Open D tuning for guitars. D2 A2 D3 F3s A3 D4.</desc>
-					      </valItem>
-					      <valItem ident="guitar.open.G">
-					         <desc xml:lang="en">Open G tuning for guitars. D2 G2 D2 G2 B3 D4.</desc>
-					      </valItem>
-					      <valItem ident="guitar.open.A">
-					         <desc xml:lang="en">Open A tuning for guitars. E2 A2 E3 A3 C4s E4.</desc>
-					      </valItem>
-					      <valItem ident="lute.renaissance.6">
-					         <desc xml:lang="en">Renaissance tuning for lutes with 10 strings on 6 courses. G2G3 C3C4 F3F4 A4A4 D4 G4.</desc>
-					      </valItem>
-					      <valItem ident="lute.baroque.d.major">
-					         <desc xml:lang="en">Baroque tuning for lutes with 6 stable courses, and additional bass courses tuned to the key of D Major.</desc>
-					      </valItem>
-					   	<valItem ident="lute.baroque.d.minor">
-					   		<desc xml:lang="en">Baroque tuning for lutes with 6 stable courses, and additional bass courses tuned to the key of D minor.</desc>
-					   	</valItem>
-					   </valList>
+						<valList type="semi">
+							<valItem ident="guitar.standard">
+								<desc xml:lang="en">Standard tuning for current guitars. The courses are tuned to E2 A2 D3 G3 B3 E4.</desc>
+							</valItem>
+							<valItem ident="guitar.drop.D">
+								<desc xml:lang="en">Drop D tuning for guitars. The lowest course is tuned down to D, while all other courses are kept to their regular pitches. D2 A2 D3 G3 B3 E4.</desc>
+							</valItem>
+							<valItem ident="guitar.open.D">
+								<desc xml:lang="en">Open D tuning for guitars. D2 A2 D3 F3s A3 D4.</desc>
+							</valItem>
+							<valItem ident="guitar.open.G">
+								<desc xml:lang="en">Open G tuning for guitars. D2 G2 D2 G2 B3 D4.</desc>
+							</valItem>
+							<valItem ident="guitar.open.A">
+								<desc xml:lang="en">Open A tuning for guitars. E2 A2 E3 A3 C4s E4.</desc>
+							</valItem>
+							<valItem ident="lute.renaissance.6">
+								<desc xml:lang="en">Renaissance tuning for lutes with 10 strings on 6 courses. G2G3 C3C4 F3F4 A4A4 D4 G4.</desc>
+							</valItem>
+							<valItem ident="lute.baroque.d.major">
+								<desc xml:lang="en">Baroque tuning for lutes with 6 stable courses, and additional bass courses tuned to the key of D Major.</desc>
+							</valItem>
+							<valItem ident="lute.baroque.d.minor">
+								<desc xml:lang="en">Baroque tuning for lutes with 6 stable courses, and additional bass courses tuned to the key of D minor.</desc>
+							</valItem>
+						</valList>
 					</content>
 				</dataSpec><classSpec rend="add" ident="att.note.ges.tab" module="MEI.frettab" type="atts" mode="add">
 					<attList>

--- a/mei/develop/mei-verovio_compiled.odd
+++ b/mei/develop/mei-verovio_compiled.odd
@@ -3429,7 +3429,14 @@
     </attList>
   </classSpec><classSpec rend="add" ident="att.accid.anl" module="MEI.analytical" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes.</desc>
+  </classSpec><classSpec rend="add" ident="att.ambitus.anl" module="MEI.analytical" type="atts">
+    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes.</desc>
+    <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+      <memberOf key="att.intervalHarmonic"/>
+    </classes>
   </classSpec><classSpec rend="add" ident="att.ambNote.anl" module="MEI.analytical" type="atts">
+    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes.</desc>
+  </classSpec><classSpec rend="add" ident="att.anchoredText.anl" module="MEI.analytical" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.annot.anl" module="MEI.analytical" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes.</desc>
@@ -3530,6 +3537,8 @@
         </valList>
       </attDef>
     </attList>
+  </classSpec><classSpec rend="add" ident="att.graceGrp.anl" module="MEI.analytical" type="atts">
+    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.harmonicFunction" module="MEI.analytical" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Attributes describing the harmonic function of a single pitch.</desc>
     <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -3624,6 +3633,8 @@
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.lv.anl" module="MEI.analytical" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes.</desc>
+  </classSpec><classSpec rend="add" ident="att.lyrics.anl" module="MEI.analytical" type="atts">
+    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.measure.anl" module="MEI.analytical" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -3641,11 +3652,15 @@
     </attList>
   </classSpec><classSpec rend="add" ident="att.mensur.anl" module="MEI.analytical" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes.</desc>
+  </classSpec><classSpec rend="add" ident="att.metaMark.anl" module="MEI.analytical" type="atts">
+    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.meterSig.anl" module="MEI.analytical" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.meterSigGrp.anl" module="MEI.analytical" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.midi.anl" module="MEI.analytical" type="atts">
+    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes.</desc>
+  </classSpec><classSpec rend="add" ident="att.mNum.anl" module="MEI.analytical" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.mordent.anl" module="MEI.analytical" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes.</desc>
@@ -3728,6 +3743,8 @@
         </datatype>
       </attDef>
     </attList>
+  </classSpec><classSpec rend="add" ident="att.plica.anl" module="MEI.analytical" type="atts">
+    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes that describe the properties of a plica in the mensural repertoire.</desc>
   </classSpec><classSpec rend="add" ident="att.proport.anl" module="MEI.analytical" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.quilisma.anl" module="MEI.analytical" type="atts">
@@ -3790,6 +3807,8 @@
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.stageDir.anl" module="MEI.analytical" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes.</desc>
+  </classSpec><classSpec rend="add" ident="att.stem.anl" module="MEI.analytical" type="atts">
+    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes that describe the properties of a stem in the mensural repertoire.</desc>
   </classSpec><classSpec rend="add" ident="att.strophicus.anl" module="MEI.analytical" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.syl.anl" module="MEI.analytical" type="atts">
@@ -4092,7 +4111,7 @@
       <memberOf key="att.beamedWith"/>
       <memberOf key="att.duration.additive"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.logical"/>
+      <memberOf key="att.timestamp2.log"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.beatRpt.log" module="MEI.cmn" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes.</desc>
@@ -4116,7 +4135,7 @@
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.logical"/>
+      <memberOf key="att.timestamp2.log"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.bracketSpan.log" module="MEI.cmn" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes.</desc>
@@ -4124,7 +4143,7 @@
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.logical"/>
+      <memberOf key="att.timestamp2.log"/>
     </classes>
     <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <attDef ident="func" usage="req">
@@ -4153,14 +4172,14 @@
       <memberOf key="att.partIdent"/>
       <memberOf key="att.staffIdent"/>
       <memberOf key="att.startId"/>
-      <memberOf key="att.timestamp.logical"/>
+      <memberOf key="att.timestamp.log"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.bTrem.log" module="MEI.cmn" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <memberOf key="att.event"/>
       <memberOf key="att.augmentDots"/>
-      <memberOf key="att.duration.logical"/>
+      <memberOf key="att.duration.log"/>
       <memberOf key="att.numbered"/>
     </classes>
     <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -4215,21 +4234,8 @@
         </valList>
       </attDef>
     </attList>
-  </classSpec><classSpec rend="add" ident="att.mNum.anl" module="MEI.cmn" type="atts">
-    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes.</desc>
-  </classSpec><classSpec rend="add" ident="att.mNum.ges" module="MEI.cmn" type="atts">
-    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.mNum.log" module="MEI.cmn" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes.</desc>
-  </classSpec><classSpec rend="add" ident="att.mNum.vis" module="MEI.cmn" type="atts">
-    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Visual domain attributes.</desc>
-    <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.color"/>
-      <memberOf key="att.placementRelStaff"/>
-      <memberOf key="att.typography"/>
-      <memberOf key="att.visualOffset"/>
-      <memberOf key="att.xy"/>
-    </classes>
   </classSpec><classSpec rend="add" ident="att.expandable" module="MEI.cmn" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Attributes that indicate whether to render a repeat symbol or the source material to which
       it refers.</desc>
@@ -4254,7 +4260,7 @@
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <memberOf key="att.event"/>
       <memberOf key="att.augmentDots"/>
-      <memberOf key="att.duration.logical"/>
+      <memberOf key="att.duration.log"/>
     </classes>
     <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <attDef ident="form" usage="opt">
@@ -4287,7 +4293,7 @@
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.logical"/>
+      <memberOf key="att.timestamp2.log"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.graced" module="MEI.cmn" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Attributes that mark a note or chord as a "grace", how it should "steal" time, and how
@@ -4307,10 +4313,6 @@
         </datatype>
       </attDef>
     </attList>
-  </classSpec><classSpec rend="add" ident="att.graceGrp.anl" module="MEI.cmn" type="atts">
-    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes.</desc>
-  </classSpec><classSpec rend="add" ident="att.graceGrp.ges" module="MEI.cmn" type="atts">
-    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.graceGrp.log" module="MEI.cmn" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -4334,18 +4336,13 @@
         </valList>
       </attDef>
     </attList>
-  </classSpec><classSpec rend="add" ident="att.graceGrp.vis" module="MEI.cmn" type="atts">
-    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Visual domain attributes.</desc>
-    <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.color"/>
-    </classes>
   </classSpec><classSpec rend="add" ident="att.hairpin.log" module="MEI.cmn" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.logical"/>
+      <memberOf key="att.timestamp2.log"/>
     </classes>
     <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <attDef ident="form" usage="req">
@@ -4372,7 +4369,7 @@
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <memberOf key="att.event"/>
-      <memberOf key="att.duration.logical"/>
+      <memberOf key="att.duration.log"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.harpPedal.log" module="MEI.cmn" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes. The pedal setting, <abbr>i.e.</abbr>, flat, natural, or sharp, for each
@@ -4498,7 +4495,7 @@
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.logical"/>
+      <memberOf key="att.timestamp2.log"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.lvPresent" module="MEI.cmn" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Attributes that indicate the presence of an l.v. (laissez vibrer) marking attached to a
@@ -4654,7 +4651,7 @@
       <memberOf key="att.duration.additive"/>
       <memberOf key="att.octaveDisplacement"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.logical"/>
+      <memberOf key="att.timestamp2.log"/>
     </classes>
     <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <attDef ident="coll" usage="opt">
@@ -4676,7 +4673,7 @@
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.logical"/>
+      <memberOf key="att.timestamp2.log"/>
     </classes>
     <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <attDef ident="dir" usage="req">
@@ -4750,8 +4747,8 @@
       <memberOf key="att.partIdent"/>
       <memberOf key="att.staffIdent"/>
       <memberOf key="att.startId"/>
-      <memberOf key="att.timestamp.logical"/>
-      <memberOf key="att.timestamp.gestural"/>
+      <memberOf key="att.timestamp.log"/>
+      <memberOf key="att.timestamp.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.rehearsal" module="MEI.cmn" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Attributes used by scoreDef and staffDef to provide default information about rehearsal
@@ -4814,7 +4811,7 @@
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.logical"/>
+      <memberOf key="att.timestamp2.log"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.slurRend" module="MEI.cmn" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Attributes that describe the rendition of slurs.</desc>
@@ -4837,6 +4834,8 @@
       <memberOf key="att.fermataPresent"/>
       <memberOf key="att.tupletPresent"/>
     </classes>
+  </classSpec><classSpec rend="add" ident="att.space.log.cmn" module="MEI.cmn" type="atts">
+    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes in the CMN repertoire.</desc>
   </classSpec><classSpec rend="add" ident="att.staffDef.log.cmn" module="MEI.cmn" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes for staffDef in the CMN repertoire.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -4869,7 +4868,7 @@
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.logical"/>
+      <memberOf key="att.timestamp2.log"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.tieRend" module="MEI.cmn" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Attributes that describe the rendition of ties.</desc>
@@ -4912,7 +4911,7 @@
       <memberOf key="att.duration.additive"/>
       <memberOf key="att.duration.ratio"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.logical"/>
+      <memberOf key="att.timestamp2.log"/>
     </classes>
   </classSpec><classSpec rend="add" predeclare="true" ident="model.controlEventLike.cmn" module="MEI.cmn" type="model">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Groups control events that appear in CMN.</desc>
@@ -5799,7 +5798,7 @@
       <memberOf key="att.duration.additive"/>
       <memberOf key="att.ornamentAccid"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.logical"/>
+      <memberOf key="att.timestamp2.log"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.turn.log" module="MEI.cmnOrnaments" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes.</desc>
@@ -6019,14 +6018,14 @@
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.logical"/>
+      <memberOf key="att.timestamp2.log"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.stageDir.log" module="MEI.drama" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.logical"/>
+      <memberOf key="att.timestamp2.log"/>
     </classes>
   </classSpec><classSpec rend="add" predeclare="true" ident="model.stageDirLike" module="MEI.drama" type="model">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Groups elements containing stage directions in performance texts.</desc>
@@ -6116,13 +6115,13 @@
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <memberOf key="att.controlEvent"/>
-      <memberOf key="att.origin.timestamp.logical"/>
+      <memberOf key="att.origin.timestamp.log"/>
       <memberOf key="att.origin.staffIdent"/>
       <memberOf key="att.origin.layerIdent"/>
       <memberOf key="att.origin.startEndId"/>
       <memberOf key="att.octaveDisplacement"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.logical"/>
+      <memberOf key="att.timestamp2.log"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.edit" module="MEI.edittrans" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Attributes describing the nature of an encoded scholarly intervention or
@@ -6131,26 +6130,14 @@
       <memberOf key="att.source"/>
       <memberOf key="att.evidence"/>
     </classes>
-  </classSpec><classSpec rend="add" ident="att.metaMark.anl" module="MEI.edittrans" type="atts">
-    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes.</desc>
-  </classSpec><classSpec rend="add" ident="att.metaMark.ges" module="MEI.edittrans" type="atts">
-    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
-    <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
-    </classes>
   </classSpec><classSpec rend="add" ident="att.metaMark.log" module="MEI.edittrans" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.logical"/>
+      <memberOf key="att.timestamp2.log"/>
       <memberOf key="att.edit"/>
       <memberOf key="att.trans"/>
-    </classes>
-  </classSpec><classSpec rend="add" ident="att.metaMark.vis" module="MEI.edittrans" type="atts">
-    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Visual domain attributes.</desc>
-    <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.placementRelStaff"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.reasonIdent" module="MEI.edittrans" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Attributes that identify the reason why an editorial feature is used.</desc>
@@ -6987,7 +6974,7 @@
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.logical"/>
+      <memberOf key="att.timestamp2.log"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.fingGrp.log" module="MEI.fingering" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes.</desc>
@@ -6995,7 +6982,7 @@
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.logical"/>
+      <memberOf key="att.timestamp2.log"/>
     </classes>
     <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <attDef ident="form" usage="opt">
@@ -7328,9 +7315,9 @@
     </content></elementSpec><classSpec rend="add" ident="att.accid.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.accidental.gestural"/>
+      <memberOf key="att.accidental.ges"/>
     </classes>
-  </classSpec><classSpec rend="add" ident="att.accidental.gestural" module="MEI.gestural" type="atts">
+  </classSpec><classSpec rend="add" ident="att.accidental.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Attributes for capturing momentary pitch inflection in the gestural domain.</desc>
     <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <attDef ident="accid.ges" usage="opt">
@@ -7348,23 +7335,27 @@
         </constraintSpec>
       </attDef>
     </attList>
+  </classSpec><classSpec rend="add" ident="att.ambitus.ges" module="MEI.gestural" type="atts">
+    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.ambNote.ges" module="MEI.gestural" type="atts">
+    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
+  </classSpec><classSpec rend="add" ident="att.anchoredText.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.annot.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
-      <memberOf key="att.timestamp.gestural"/>
-      <memberOf key="att.timestamp2.gestural"/>
+      <memberOf key="att.duration.ges"/>
+      <memberOf key="att.timestamp.ges"/>
+      <memberOf key="att.timestamp2.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.arpeg.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.artic.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.articulation.gestural"/>
+      <memberOf key="att.articulation.ges"/>
     </classes>
-  </classSpec><classSpec rend="add" ident="att.articulation.gestural" module="MEI.gestural" type="atts">
+  </classSpec><classSpec rend="add" ident="att.articulation.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Attributes describing the method of performance.</desc>
     <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <attDef ident="artic.ges" usage="opt">
@@ -7377,7 +7368,7 @@
   </classSpec><classSpec rend="add" ident="att.attacca.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.timestamp2.gestural"/>
+      <memberOf key="att.timestamp2.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.barLine.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
@@ -7386,15 +7377,15 @@
   </classSpec><classSpec rend="add" ident="att.beamSpan.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
-      <memberOf key="att.timestamp2.gestural"/>
+      <memberOf key="att.duration.ges"/>
+      <memberOf key="att.timestamp2.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.beatRpt.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.bend.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.timestamp2.gestural"/>
+      <memberOf key="att.timestamp2.ges"/>
     </classes>
     <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <attDef ident="amount" usage="opt">
@@ -7408,13 +7399,13 @@
   </classSpec><classSpec rend="add" ident="att.bracketSpan.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
-      <memberOf key="att.timestamp2.gestural"/>
+      <memberOf key="att.duration.ges"/>
+      <memberOf key="att.timestamp2.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.breath.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.timestamp.gestural"/>
+      <memberOf key="att.timestamp.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.bTrem.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
@@ -7424,14 +7415,14 @@
   </classSpec><classSpec rend="add" ident="att.caesura.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
-      <memberOf key="att.timestamp.gestural"/>
+      <memberOf key="att.duration.ges"/>
+      <memberOf key="att.timestamp.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.chord.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.articulation.gestural"/>
-      <memberOf key="att.duration.gestural"/>
+      <memberOf key="att.articulation.ges"/>
+      <memberOf key="att.duration.ges"/>
       <memberOf key="att.instrumentIdent"/>
       <memberOf key="att.chord.ges.cmn"/>
     </classes>
@@ -7440,7 +7431,7 @@
   </classSpec><classSpec rend="add" ident="att.chordMember.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.accidental.gestural"/>
+      <memberOf key="att.accidental.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.clef.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
@@ -7449,8 +7440,8 @@
   </classSpec><classSpec rend="add" ident="att.cpMark.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
-      <memberOf key="att.timestamp2.gestural"/>
+      <memberOf key="att.duration.ges"/>
+      <memberOf key="att.timestamp2.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.curve.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
@@ -7470,12 +7461,12 @@
   </classSpec><classSpec rend="add" ident="att.dir.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
-      <memberOf key="att.timestamp2.gestural"/>
+      <memberOf key="att.duration.ges"/>
+      <memberOf key="att.timestamp2.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.dot.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
-  </classSpec><classSpec rend="add" ident="att.duration.gestural" module="MEI.gestural" type="atts">
+  </classSpec><classSpec rend="add" ident="att.duration.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Attributes that record performed duration that differs from a feature’s written
       duration.</desc>
     <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -7527,40 +7518,40 @@
   </classSpec><classSpec rend="add" ident="att.dynam.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
+      <memberOf key="att.duration.ges"/>
       <memberOf key="att.midiValue"/>
       <memberOf key="att.midiValue2"/>
-      <memberOf key="att.timestamp2.gestural"/>
+      <memberOf key="att.timestamp2.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.ending.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.episema.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.articulation.gestural"/>
+      <memberOf key="att.articulation.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.f.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
-      <memberOf key="att.timestamp2.gestural"/>
+      <memberOf key="att.duration.ges"/>
+      <memberOf key="att.timestamp2.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.fermata.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
+      <memberOf key="att.duration.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.fing.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
-      <memberOf key="att.timestamp2.gestural"/>
+      <memberOf key="att.duration.ges"/>
+      <memberOf key="att.timestamp2.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.fingGrp.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
-      <memberOf key="att.timestamp2.gestural"/>
+      <memberOf key="att.duration.ges"/>
+      <memberOf key="att.timestamp2.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.fTrem.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
@@ -7570,34 +7561,36 @@
   </classSpec><classSpec rend="add" ident="att.gliss.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
-      <memberOf key="att.timestamp2.gestural"/>
+      <memberOf key="att.duration.ges"/>
+      <memberOf key="att.timestamp2.ges"/>
     </classes>
+  </classSpec><classSpec rend="add" ident="att.graceGrp.ges" module="MEI.gestural" type="atts">
+    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.grpSym.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.hairpin.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
+      <memberOf key="att.duration.ges"/>
       <memberOf key="att.midiValue"/>
       <memberOf key="att.midiValue2"/>
-      <memberOf key="att.timestamp2.gestural"/>
+      <memberOf key="att.timestamp2.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.halfmRpt.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
+      <memberOf key="att.duration.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.harm.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
-      <memberOf key="att.timestamp2.gestural"/>
+      <memberOf key="att.duration.ges"/>
+      <memberOf key="att.timestamp2.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.harpPedal.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
+      <memberOf key="att.duration.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.hispanTick.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
@@ -7625,15 +7618,15 @@
   </classSpec><classSpec rend="add" ident="att.line.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Attributes for describing the performed components of a line.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
-      <memberOf key="att.timestamp2.gestural"/>
+      <memberOf key="att.duration.ges"/>
+      <memberOf key="att.timestamp2.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.liquescent.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.lv.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.timestamp2.gestural"/>
+      <memberOf key="att.timestamp2.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.lyrics.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
@@ -7642,22 +7635,29 @@
       time of the measure. In reality, this is usually the same as the onset time of the first event
       in the measure.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.timestamp.gestural"/>
+      <memberOf key="att.timestamp.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.mensur.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
+  </classSpec><classSpec rend="add" ident="att.metaMark.ges" module="MEI.gestural" type="atts">
+    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
+    <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+      <memberOf key="att.duration.ges"/>
+    </classes>
   </classSpec><classSpec rend="add" ident="att.meterSig.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.meterSigGrp.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.midi.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
+  </classSpec><classSpec rend="add" ident="att.mNum.ges" module="MEI.gestural" type="atts">
+    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.mordent.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.mRest.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
+      <memberOf key="att.duration.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.mRpt.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
@@ -7666,12 +7666,12 @@
   </classSpec><classSpec rend="add" ident="att.mSpace.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
+      <memberOf key="att.duration.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.multiRest.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
+      <memberOf key="att.duration.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.multiRpt.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
@@ -7679,9 +7679,9 @@
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       
-      <memberOf key="att.accidental.gestural"/>
-      <memberOf key="att.articulation.gestural"/>
-      <memberOf key="att.duration.gestural"/>
+      <memberOf key="att.accidental.ges"/>
+      <memberOf key="att.articulation.ges"/>
+      <memberOf key="att.duration.ges"/>
       <memberOf key="att.instrumentIdent"/>
       <memberOf key="att.midiVelocity"/>
     </classes>
@@ -7708,19 +7708,19 @@
   </classSpec><classSpec rend="add" ident="att.ncGrp.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.timestamp.gestural"/>
+      <memberOf key="att.timestamp.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.neume.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.timestamp.gestural"/>
+      <memberOf key="att.timestamp.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.note.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.accidental.gestural"/>
-      <memberOf key="att.articulation.gestural"/>
-      <memberOf key="att.duration.gestural"/>
+      <memberOf key="att.accidental.ges"/>
+      <memberOf key="att.articulation.ges"/>
+      <memberOf key="att.duration.ges"/>
       <memberOf key="att.instrumentIdent"/>
       <memberOf key="att.midiVelocity"/>
       <memberOf key="att.note.ges.mensural"/>
@@ -7775,16 +7775,16 @@
   </classSpec><classSpec rend="add" ident="att.octave.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
-      <memberOf key="att.timestamp2.gestural"/>
+      <memberOf key="att.duration.ges"/>
+      <memberOf key="att.timestamp2.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.oriscus.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.ornam.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
-      <memberOf key="att.timestamp2.gestural"/>
+      <memberOf key="att.duration.ges"/>
+      <memberOf key="att.timestamp2.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.ornamentAccid.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural accidentals associated with ornaments.</desc>
@@ -7815,14 +7815,16 @@
   </classSpec><classSpec rend="add" ident="att.pedal.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.timestamp2.gestural"/>
+      <memberOf key="att.timestamp2.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.phrase.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
-      <memberOf key="att.timestamp2.gestural"/>
+      <memberOf key="att.duration.ges"/>
+      <memberOf key="att.timestamp2.ges"/>
     </classes>
+  </classSpec><classSpec rend="add" ident="att.plica.ges" module="MEI.gestural" type="atts">
+    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes that describe the properties of a plica in the mensural repertoire.</desc>
   </classSpec><classSpec rend="add" ident="att.proport.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.quilisma.ges" module="MEI.gestural" type="atts">
@@ -7836,7 +7838,7 @@
   </classSpec><classSpec rend="add" ident="att.rest.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
+      <memberOf key="att.duration.ges"/>
       <memberOf key="att.rest.ges.mensural"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.sb.ges" module="MEI.gestural" type="atts">
@@ -7874,8 +7876,8 @@
   </classSpec><classSpec rend="add" ident="att.slur.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
-      <memberOf key="att.timestamp2.gestural"/>
+      <memberOf key="att.duration.ges"/>
+      <memberOf key="att.timestamp2.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.soundLocation" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Attributes that locate a sound source within 3-D space.</desc>
@@ -7904,12 +7906,12 @@
   </classSpec><classSpec rend="add" ident="att.sp.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.timestamp2.gestural"/>
+      <memberOf key="att.timestamp2.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.space.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
+      <memberOf key="att.duration.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.staff.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
@@ -7929,8 +7931,10 @@
   </classSpec><classSpec rend="add" ident="att.stageDir.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.timestamp2.gestural"/>
+      <memberOf key="att.timestamp2.ges"/>
     </classes>
+  </classSpec><classSpec rend="add" ident="att.stem.ges" module="MEI.gestural" type="atts">
+    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes that describe the properties of a stem in the mensural repertoire.</desc>
   </classSpec><classSpec rend="add" ident="att.strophicus.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.syl.ges" module="MEI.gestural" type="atts">
@@ -7947,9 +7951,9 @@
   </classSpec><classSpec rend="add" ident="att.tie.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.timestamp2.gestural"/>
+      <memberOf key="att.timestamp2.ges"/>
     </classes>
-  </classSpec><classSpec rend="add" ident="att.timestamp.gestural" module="MEI.gestural" type="atts">
+  </classSpec><classSpec rend="add" ident="att.timestamp.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Attributes that record a performed (as opposed to notated) time stamp.</desc>
     <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <attDef ident="tstamp.ges" usage="opt">
@@ -7966,7 +7970,7 @@
         </datatype>
       </attDef>
     </attList>
-  </classSpec><classSpec rend="add" ident="att.timestamp2.gestural" module="MEI.gestural" type="atts">
+  </classSpec><classSpec rend="add" ident="att.timestamp2.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Attributes that record a performed (as opposed to notated) time stamp for the end of an
       event.</desc>
     <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -7987,18 +7991,18 @@
   </classSpec><classSpec rend="add" ident="att.trill.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
-      <memberOf key="att.timestamp2.gestural"/>
+      <memberOf key="att.duration.ges"/>
+      <memberOf key="att.timestamp2.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.tuplet.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.duration.gestural"/>
+      <memberOf key="att.duration.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.tupletSpan.ges" module="MEI.gestural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.timestamp2.gestural"/>
+      <memberOf key="att.timestamp2.ges"/>
       <memberOf key="att.tuplet.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.turn.ges" module="MEI.gestural" type="atts">
@@ -8025,7 +8029,7 @@
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.logical"/>
+      <memberOf key="att.timestamp2.log"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.harm.log" module="MEI.harmony" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes.</desc>
@@ -8033,7 +8037,7 @@
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.logical"/>
+      <memberOf key="att.timestamp2.log"/>
     </classes>
     <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <attDef ident="chordref" usage="opt">
@@ -9048,7 +9052,7 @@
       <memberOf key="att.lang"/>
       <memberOf key="model.editorialDeclPart"/>
     </classes><content xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <zeroOrMore xmlns="http://relaxng.org/ns/structure/1.0"><ref name=""/></zeroOrMore>
+      <zeroOrMore xmlns="http://relaxng.org/ns/structure/1.0"><ref name="model.headLike"/></zeroOrMore>
       <oneOrMore xmlns="http://relaxng.org/ns/structure/1.0"><ref name="model.pLike"/></oneOrMore>
     </content><remarks xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">
       <p>The model of this element is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-interpretation.html">interpretation</ref> element of the Text Encoding Initiative (TEI).</p>
@@ -10164,28 +10168,8 @@
         </datatype>
       </attDef>
     </attList>
-  </classSpec><classSpec rend="add" ident="att.plica.anl" module="MEI.mensural" type="atts">
-    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes that describe the properties of a plica in the mensural repertoire.</desc>
-  </classSpec><classSpec rend="add" ident="att.plica.ges" module="MEI.mensural" type="atts">
-    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes that describe the properties of a plica in the mensural repertoire.</desc>
   </classSpec><classSpec rend="add" ident="att.plica.log" module="MEI.mensural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes that describe the properties of a plica in the mensural repertoire.</desc>
-  </classSpec><classSpec rend="add" ident="att.plica.vis" module="MEI.mensural" type="atts">
-    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Visual domain attributes that describe the properties of a plica stem in the mensural repertoire.</desc>
-    <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <attDef ident="dir" usage="opt">
-        <desc xml:lang="en">Describes the direction of a stem.</desc>
-        <datatype>
-          <ref xmlns="http://relaxng.org/ns/structure/1.0" name="data.STEMDIRECTION.basic"/>
-        </datatype>
-      </attDef>
-      <attDef ident="len" usage="opt">
-        <desc xml:lang="en">Encodes the stem length.</desc>
-        <datatype>
-          <ref xmlns="http://relaxng.org/ns/structure/1.0" name="data.MEASUREMENTUNSIGNED"/>
-        </datatype>
-      </attDef>
-    </attList>
   </classSpec><classSpec rend="add" ident="att.proport.log" module="MEI.mensural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes. These attributes describe augmentation or diminution of the
       normal value of the notes in mensural notation as a ratio.</desc>
@@ -10229,58 +10213,8 @@
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <memberOf key="att.mensural.vis"/>
     </classes>
-  </classSpec><classSpec rend="add" ident="att.stem.anl" module="MEI.mensural" type="atts">
-    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes that describe the properties of a stem in the mensural repertoire.</desc>
-  </classSpec><classSpec rend="add" ident="att.stem.ges" module="MEI.mensural" type="atts">
-    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes that describe the properties of a stem in the mensural repertoire.</desc>
   </classSpec><classSpec rend="add" ident="att.stem.log" module="MEI.mensural" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes that describe the properties of a stem in the mensural repertoire.</desc>
-  </classSpec><classSpec rend="add" ident="att.stem.vis" module="MEI.mensural" type="atts">
-    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Visual domain attributes that describe the properties of a stem in the mensural repertoire.</desc>
-    <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-        <memberOf key="att.xy"/>
-        <memberOf key="att.color"/>
-        <memberOf key="att.extSym"/>
-        <memberOf key="att.visibility"/>
-    </classes>
-    <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <attDef ident="pos" usage="opt">
-        <desc xml:lang="en">Records the position of the stem in relation to the note head(s).</desc>
-        <datatype>
-          <ref xmlns="http://relaxng.org/ns/structure/1.0" name="data.STEMPOSITION"/>
-        </datatype>
-      </attDef>
-      <attDef ident="len" usage="opt">
-        <desc xml:lang="en">Encodes the stem length.</desc>
-        <datatype>
-          <ref xmlns="http://relaxng.org/ns/structure/1.0" name="data.MEASUREMENTUNSIGNED"/>
-        </datatype>
-      </attDef>
-      <attDef ident="form" usage="opt">
-        <desc xml:lang="en">Encodes the form of the stem using the values provided by the data.STEMFORM.mensural datatype.</desc>
-        <datatype>
-          <ref xmlns="http://relaxng.org/ns/structure/1.0" name="data.STEMFORM.mensural"/>
-        </datatype>
-      </attDef>
-      <attDef ident="dir" usage="opt">
-        <desc xml:lang="en">Describes the direction of a stem.</desc>
-        <datatype>
-          <ref xmlns="http://relaxng.org/ns/structure/1.0" name="data.STEMDIRECTION"/>
-        </datatype>
-      </attDef>
-      <attDef ident="flag.pos" usage="opt">
-        <desc xml:lang="en">Records the position of the flag using the values provided by the data.FLAGPOS.mensural datatype.</desc>
-        <datatype>
-          <ref xmlns="http://relaxng.org/ns/structure/1.0" name="data.FLAGPOS.mensural"/>
-        </datatype>
-      </attDef>
-      <attDef ident="flag.form" usage="opt">
-        <desc xml:lang="en">Encodes the form of the flag using the values provided by the data.FLAGFORM.mensural datatype.</desc>
-        <datatype>
-          <ref xmlns="http://relaxng.org/ns/structure/1.0" name="data.FLAGFORM.mensural"/>
-        </datatype>
-      </attDef>
-    </attList>
   </classSpec><classSpec rend="add" ident="att.stems.mensural" module="MEI.mensural" type="atts">
       <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Attributes that describe the properties of stemmed features specific to mensural repertoires.</desc>
       <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -10301,11 +10235,6 @@
       repertoire.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <memberOf key="model.layerPart.mensuralAndNeumes"/>
-    </classes>
-  </classSpec><classSpec rend="add" predeclare="true" ident="model.sectionPart.mensural" module="MEI.mensural" type="model">
-    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Groups elements that may appear as part of a section in the mensural repertoire.</desc>
-    <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="model.sectionPart.mensuralAndNeumes"/>
     </classes>
   </classSpec><classSpec rend="add" predeclare="true" ident="model.staffDefPart.mensural" module="MEI.mensural" type="model">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Groups elements that may appear in the declaration of staff features.</desc>
@@ -10457,8 +10386,8 @@
       <memberOf key="att.layerIdent"/>
       <memberOf key="att.partIdent"/>
       <memberOf key="att.staffIdent"/>
-      <memberOf key="att.timestamp.logical"/>
-      <memberOf key="att.timestamp.gestural"/>
+      <memberOf key="att.timestamp.log"/>
+      <memberOf key="att.timestamp.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.midi.log" module="MEI.midi" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes.</desc>
@@ -11237,16 +11166,6 @@
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Groups elements that modify neume-like features.</desc>
   </classSpec><classSpec rend="add" predeclare="true" ident="model.neumePart" module="MEI.neumes" type="model">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Groups elements that may occur within a neume.</desc>
-  </classSpec><classSpec rend="add" predeclare="true" ident="model.sectionPart.neumes" module="MEI.neumes" type="model">
-    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Groups elements that may appear as part of a section in the neume repertoire.</desc>
-    <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="model.sectionPart.mensuralAndNeumes"/>
-    </classes>
-  </classSpec><classSpec rend="add" predeclare="true" ident="model.staffPart.neumes" module="MEI.neumes" type="model">
-    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Groups elements that are components of a staff in the neume repertoire.</desc>
-    <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="model.staffPart.mensuralAndNeumes"/>
-    </classes>
   </classSpec><classSpec rend="add" predeclare="true" ident="model.syllableLike" module="MEI.neumes" type="model">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Groups elements that accommodate neumed text.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -11779,34 +11698,15 @@
         </datatype>
       </attDef>
     </attList>
-  </classSpec><classSpec rend="add" ident="att.ambitus.anl" module="MEI.shared" type="atts">
-    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes.</desc>
-    <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.intervalHarmonic"/>
-    </classes>
-  </classSpec><classSpec rend="add" ident="att.ambitus.ges" module="MEI.shared" type="atts">
-    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.ambitus.log" module="MEI.shared" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes.</desc>
-  </classSpec><classSpec rend="add" ident="att.ambitus.vis" module="MEI.shared" type="atts">
-    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Visual domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.ambNote.log" module="MEI.shared" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <memberOf key="att.accidental"/>
       <memberOf key="att.coloration"/>
-      <memberOf key="att.duration.logical"/>
+      <memberOf key="att.duration.log"/>
       <memberOf key="att.pitched"/>
-    </classes>
-  </classSpec><classSpec rend="add" ident="att.anchoredText.anl" module="MEI.shared" type="atts">
-    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Analytical domain attributes.</desc>
-  </classSpec><classSpec rend="add" ident="att.anchoredText.ges" module="MEI.shared" type="atts">
-    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Gestural domain attributes.</desc>
-  </classSpec><classSpec rend="add" ident="att.anchoredText.vis" module="MEI.shared" type="atts">
-    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Visual domain attributes.</desc>
-    <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.visualOffset"/>
-      <memberOf key="att.xy"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.annot.log" module="MEI.shared" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes for annot. Values for the type attribute can be taken from any
@@ -11820,8 +11720,8 @@
       <memberOf key="att.partIdent"/>
       <memberOf key="att.staffIdent"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp.logical"/>
-      <memberOf key="att.timestamp2.logical"/>
+      <memberOf key="att.timestamp.log"/>
+      <memberOf key="att.timestamp2.log"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.artic.log" module="MEI.shared" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes.</desc>
@@ -11847,7 +11747,7 @@
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.logical"/>
+      <memberOf key="att.timestamp2.log"/>
     </classes>
     <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <attDef ident="target" usage="opt">
@@ -12027,7 +11927,7 @@
       <memberOf key="att.partIdent"/>
       <memberOf key="att.staffIdent"/>
       <memberOf key="att.startId"/>
-      <memberOf key="att.timestamp.logical"/>
+      <memberOf key="att.timestamp.log"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.calendared" module="MEI.shared" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Attributes that indicate the calendar system of a date or other datable element.</desc>
@@ -12065,7 +11965,7 @@
       <memberOf key="att.augmentDots"/>
       <memberOf key="att.chord.log.cmn"/>
       <memberOf key="att.cue"/>
-      <memberOf key="att.duration.logical"/>
+      <memberOf key="att.duration.log"/>
       <memberOf key="att.event"/>
       <memberOf key="att.sylText"/>
     </classes>
@@ -12214,8 +12114,8 @@
       <memberOf key="att.plist"/>
       <memberOf key="att.staffIdent"/>
       <memberOf key="att.targetEval"/>
-      <memberOf key="att.timestamp.logical"/>
-      <memberOf key="att.timestamp.gestural"/>
+      <memberOf key="att.timestamp.log"/>
+      <memberOf key="att.timestamp.ges"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.coordinated" module="MEI.shared" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">This attribute class records the position of a feature within a two-dimensional coordinate
@@ -12443,7 +12343,7 @@
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.logical"/>
+      <memberOf key="att.timestamp2.log"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.distances" module="MEI.shared" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Attributes that describe distance from the staff.</desc>
@@ -12534,7 +12434,7 @@
         </datatype>
       </attDef>
     </attList>
-  </classSpec><classSpec rend="add" ident="att.duration.logical" module="MEI.shared" type="atts">
+  </classSpec><classSpec rend="add" ident="att.duration.log" module="MEI.shared" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Attributes that express duration in musical terms.</desc>
     <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <attDef ident="dur" usage="opt">
@@ -12569,7 +12469,7 @@
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.logical"/>
+      <memberOf key="att.timestamp2.log"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.enclosingChars" module="MEI.shared" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Attributes that capture characters used to enclose symbols having a cautionary or
@@ -12613,8 +12513,8 @@
       <memberOf key="att.alignment"/>
       <memberOf key="att.layerIdent"/>
       <memberOf key="att.staffIdent"/>
-      <memberOf key="att.timestamp.gestural"/>
-      <memberOf key="att.timestamp.logical"/>
+      <memberOf key="att.timestamp.ges"/>
+      <memberOf key="att.timestamp.log"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.evidence" module="MEI.shared" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Attributes describing the support for and the certainty of an assertion.</desc>
@@ -13576,7 +13476,7 @@
       <memberOf key="att.augmentDots"/>
       <memberOf key="att.coloration"/>
       <memberOf key="att.cue"/>
-      <memberOf key="att.duration.logical"/>
+      <memberOf key="att.duration.log"/>
       <memberOf key="att.event"/>
       <memberOf key="att.note.log.cmn"/>
       <memberOf key="att.note.log.mensural"/>
@@ -13775,7 +13675,7 @@
         </datatype>
       </attDef>
     </attList>
-  </classSpec><classSpec rend="add" ident="att.origin.timestamp.logical" module="MEI.shared" type="atts">
+  </classSpec><classSpec rend="add" ident="att.origin.timestamp.log" module="MEI.shared" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Attributes that identify a musical range in terms of musical time.</desc>
     <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <attDef ident="origin.tstamp" usage="opt">
@@ -13809,7 +13709,7 @@
       <memberOf key="att.duration.additive"/>
       <memberOf key="att.ornamentAccid"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.logical"/>
+      <memberOf key="att.timestamp2.log"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.pad.log" module="MEI.shared" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes.</desc>
@@ -13924,7 +13824,7 @@
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.logical"/>
+      <memberOf key="att.timestamp2.log"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.pitch" module="MEI.shared" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Attributes that record written pitch name.</desc>
@@ -14157,11 +14057,11 @@
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <memberOf key="att.augmentDots"/>
       <memberOf key="att.cue"/>
-      <memberOf key="att.restduration.logical"/>
+      <memberOf key="att.restduration.log"/>
       <memberOf key="att.event"/>
       <memberOf key="att.rest.log.cmn"/>
     </classes>
-  </classSpec><classSpec rend="add" ident="att.restduration.logical" module="MEI.shared" type="atts">
+  </classSpec><classSpec rend="add" ident="att.restduration.log" module="MEI.shared" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Attributes that express duration of rests in musical terms.</desc>
     <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <attDef ident="dur" usage="opt">
@@ -14266,8 +14166,9 @@
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <memberOf key="att.augmentDots"/>
-      <memberOf key="att.duration.logical"/>
+      <memberOf key="att.duration.log"/>
       <memberOf key="att.event"/>
+      <memberOf key="att.space.log.cmn"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.spacing" module="MEI.shared" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Attributes that capture notation spacing information.</desc>
@@ -14689,7 +14590,7 @@
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.mmTempo"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.logical"/>
+      <memberOf key="att.timestamp2.log"/>
     </classes>
     <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <attDef ident="func">
@@ -14783,7 +14684,7 @@
         </datatype>
       </attDef>
     </attList>
-  </classSpec><classSpec rend="add" ident="att.timestamp.logical" module="MEI.shared" type="atts">
+  </classSpec><classSpec rend="add" ident="att.timestamp.log" module="MEI.shared" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Attributes that record a time stamp in terms of musical time, <abbr>i.e.</abbr>, beats[.fractional beat
       part].</desc>
     <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -14795,7 +14696,7 @@
         </datatype>
       </attDef>
     </attList>
-  </classSpec><classSpec rend="add" ident="att.timestamp2.logical" module="MEI.shared" type="atts">
+  </classSpec><classSpec rend="add" ident="att.timestamp2.log" module="MEI.shared" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Attributes that record a time stamp for the end of an event in terms of musical
       time.</desc>
     <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -15383,12 +15284,6 @@
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Groups elements that represent a score.</desc>
   </classSpec><classSpec rend="add" predeclare="true" ident="model.scorePart" module="MEI.shared" type="model">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Groups elements that may appear as part of a score.</desc>
-  </classSpec><classSpec rend="add" predeclare="true" ident="model.scorePart.mensuralAndNeumes" module="MEI.shared" type="model">
-    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Groups elements that may appear as part of a score in the mensural and neumes
-      repertoires.</desc>
-    <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="model.scorePart"/>
-    </classes>
   </classSpec><classSpec rend="add" predeclare="true" ident="model.sectionLike" module="MEI.shared" type="model">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Groups elements that represent a segment of music notation.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -16634,6 +16529,7 @@
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
       <memberOf key="att.lang"/>
+      <memberOf key="att.lyrics.anl"/>
       <memberOf key="att.lyrics.ges"/>
       <memberOf key="att.lyrics.log"/>
       <memberOf key="att.lyrics.vis"/>
@@ -18202,7 +18098,7 @@
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.logical"/>
+      <memberOf key="att.timestamp2.log"/>
     </classes>
     <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <attDef ident="func" usage="rec">
@@ -18397,6 +18293,8 @@
       <memberOf key="att.visualOffset.vo"/>
       <memberOf key="att.xy"/>
     </classes>
+  </classSpec><classSpec rend="add" ident="att.ambitus.vis" module="MEI.visual" type="atts">
+    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Visual domain attributes.</desc>
   </classSpec><classSpec rend="add" ident="att.ambNote.vis" module="MEI.visual" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Visual domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -18406,6 +18304,12 @@
       <memberOf key="att.staffLoc"/>
       <memberOf key="att.stems"/>
       <memberOf key="att.typography"/>
+    </classes>
+  </classSpec><classSpec rend="add" ident="att.anchoredText.vis" module="MEI.visual" type="atts">
+    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Visual domain attributes.</desc>
+    <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+      <memberOf key="att.visualOffset"/>
+      <memberOf key="att.xy"/>
     </classes>
   </classSpec><classSpec rend="add" ident="att.annot.vis" module="MEI.visual" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Visual domain attributes.</desc>
@@ -18972,6 +18876,11 @@
       <memberOf key="att.xy2"/>
       <memberOf key="att.lineRend"/>
     </classes>
+  </classSpec><classSpec rend="add" ident="att.graceGrp.vis" module="MEI.visual" type="atts">
+    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Visual domain attributes.</desc>
+    <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+      <memberOf key="att.color"/>
+    </classes>
   </classSpec><classSpec rend="add" ident="att.grpSym.vis" module="MEI.visual" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Visual domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -19386,6 +19295,11 @@
         </datatype>
       </attDef>
     </attList>
+  </classSpec><classSpec rend="add" ident="att.metaMark.vis" module="MEI.visual" type="atts">
+    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Visual domain attributes.</desc>
+    <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+      <memberOf key="att.placementRelStaff"/>
+    </classes>
   </classSpec><classSpec rend="add" ident="att.meterSig.vis" module="MEI.visual" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Visual domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -19423,6 +19337,15 @@
     </attList>
   </classSpec><classSpec rend="add" ident="att.meterSigGrp.vis" module="MEI.visual" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Visual domain attributes.</desc>
+  </classSpec><classSpec rend="add" ident="att.mNum.vis" module="MEI.visual" type="atts">
+    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Visual domain attributes.</desc>
+    <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+      <memberOf key="att.color"/>
+      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.typography"/>
+      <memberOf key="att.visualOffset"/>
+      <memberOf key="att.xy"/>
+    </classes>
   </classSpec><classSpec rend="add" ident="att.mordent.vis" module="MEI.visual" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Visual domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -19650,6 +19573,22 @@
       <memberOf key="att.xy2"/>
       <memberOf key="att.phrase.vis.cmn"/>
     </classes>
+  </classSpec><classSpec rend="add" ident="att.plica.vis" module="MEI.visual" type="atts">
+    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Visual domain attributes that describe the properties of a plica stem in the mensural repertoire.</desc>
+    <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+      <attDef ident="dir" usage="opt">
+        <desc xml:lang="en">Describes the direction of a stem.</desc>
+        <datatype>
+          <ref xmlns="http://relaxng.org/ns/structure/1.0" name="data.STEMDIRECTION.basic"/>
+        </datatype>
+      </attDef>
+      <attDef ident="len" usage="opt">
+        <desc xml:lang="en">Encodes the stem length.</desc>
+        <datatype>
+          <ref xmlns="http://relaxng.org/ns/structure/1.0" name="data.MEASUREMENTUNSIGNED"/>
+        </datatype>
+      </attDef>
+    </attList>
   </classSpec><classSpec rend="add" ident="att.proport.vis" module="MEI.visual" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Visual domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -19936,6 +19875,52 @@
       <memberOf key="att.visualOffset2.to"/>
       <memberOf key="att.xy"/>
     </classes>
+  </classSpec><classSpec rend="add" ident="att.stem.vis" module="MEI.visual" type="atts">
+    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Visual domain attributes that describe the properties of a stem in the mensural repertoire.</desc>
+    <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+      <memberOf key="att.xy"/>
+      <memberOf key="att.color"/>
+      <memberOf key="att.extSym"/>
+      <memberOf key="att.visibility"/>
+    </classes>
+    <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+      <attDef ident="pos" usage="opt">
+        <desc xml:lang="en">Records the position of the stem in relation to the note head(s).</desc>
+        <datatype>
+          <ref xmlns="http://relaxng.org/ns/structure/1.0" name="data.STEMPOSITION"/>
+        </datatype>
+      </attDef>
+      <attDef ident="len" usage="opt">
+        <desc xml:lang="en">Encodes the stem length.</desc>
+        <datatype>
+          <ref xmlns="http://relaxng.org/ns/structure/1.0" name="data.MEASUREMENTUNSIGNED"/>
+        </datatype>
+      </attDef>
+      <attDef ident="form" usage="opt">
+        <desc xml:lang="en">Encodes the form of the stem using the values provided by the data.STEMFORM.mensural datatype.</desc>
+        <datatype>
+          <ref xmlns="http://relaxng.org/ns/structure/1.0" name="data.STEMFORM.mensural"/>
+        </datatype>
+      </attDef>
+      <attDef ident="dir" usage="opt">
+        <desc xml:lang="en">Describes the direction of a stem.</desc>
+        <datatype>
+          <ref xmlns="http://relaxng.org/ns/structure/1.0" name="data.STEMDIRECTION"/>
+        </datatype>
+      </attDef>
+      <attDef ident="flag.pos" usage="opt">
+        <desc xml:lang="en">Records the position of the flag using the values provided by the data.FLAGPOS.mensural datatype.</desc>
+        <datatype>
+          <ref xmlns="http://relaxng.org/ns/structure/1.0" name="data.FLAGPOS.mensural"/>
+        </datatype>
+      </attDef>
+      <attDef ident="flag.form" usage="opt">
+        <desc xml:lang="en">Encodes the form of the flag using the values provided by the data.FLAGFORM.mensural datatype.</desc>
+        <datatype>
+          <ref xmlns="http://relaxng.org/ns/structure/1.0" name="data.FLAGFORM.mensural"/>
+        </datatype>
+      </attDef>
+    </attList>
   </classSpec><classSpec rend="add" ident="att.strophicus.vis" module="MEI.visual" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Visual domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -20101,11 +20086,11 @@
 					</content></elementSpec><classSpec rend="add" predeclare="true" ident="model.pageLike" type="model" module="MEI.pageBased" mode="add">
 					<desc xml:lang="en">Collects pageLike elements.</desc>
 				</classSpec><elementSpec rend="add" ident="page" module="MEI.pageBased" mode="add"><desc xml:lang="en">A page in a page-base encoding</desc><classes>
-						<memberOf key="att.pages"/>
 						
 						<memberOf key="att.common"/>
+						<memberOf key="att.facsimile"/>
 						
-						<memberOf key="att.surface"/>
+						<memberOf key="att.pages"/>
 						<memberOf key="model.pageLike"/>
 					</classes><content>
 						<zeroOrMore xmlns="http://relaxng.org/ns/structure/1.0"><choice><ref name="model.systemLike"/><ref name="model.milestoneLike"/><ref name="model.secbLike"/><ref name="model.mdivbLike"/><ref name="model.scoreLike"/><ref name="model.partsLike"/></choice></zeroOrMore>
@@ -20223,16 +20208,6 @@
 						<memberOf key="att.coord.x1"/>
 						<memberOf key="att.coord.x2"/>
 					</classes>
-				</classSpec><classSpec rend="add" ident="att.surface" module="MEI.pageBased" type="atts" mode="add">
-					<desc xml:lang="en">This attribute is used to point to a surface.</desc>
-					<attList>
-						<attDef ident="surface" usage="opt">
-							<desc xml:lang="en">contains a reference to a surface element</desc>
-							<datatype>
-								<dataRef key="data.URI"/>
-							</datatype>
-						</attDef>
-					</attList>
 				</classSpec><moduleSpec ident="MEI.frettab" mode="add">
 					<desc/>
 				</moduleSpec><dataSpec rend="add" ident="data.COURSENUMBER" module="MEI.frettab" mode="add">

--- a/tools/langs/cplusplus_vrv.py
+++ b/tools/langs/cplusplus_vrv.py
@@ -84,7 +84,7 @@ ENUM_GRP_END = """    ATT_CLASS_max
 """
 
 #
-# These templates the type definintions
+# These templates generate the type definitions
 #
 
 TYPE_GRP_START = """
@@ -212,7 +212,7 @@ CONVERTER_IMPL_TEMPLATE_END = """
 
 
 #
-# These templates generate a module level static method for setting attribute on an unspcified Object
+# These templates generate a module level static method for setting attribute on an unspecified Object
 #
 
 SETTERS_IMPL_TEMPLATE_START = """bool Att::Set{moduleNameCap}(Object *element, const std::string &attrType, const std::string &attrValue)
@@ -240,7 +240,7 @@ SETTERS_IMPL_TEMPLATE_END = """
 """
 
 #
-# These templates generate a module level static method for getting attributes of an unspcified Object
+# These templates generate a module level static method for getting attributes of an unspecified Object
 #
 
 GETTERS_IMPL_TEMPLATE_START = """void Att::Get{moduleNameCap}(const Object *element, ArrayOfStrAttr *attributes)

--- a/tools/langs/cplusplus_vrv.py
+++ b/tools/langs/cplusplus_vrv.py
@@ -507,7 +507,7 @@ def vrv_getatttype(schema, module, gp, aname, includes_dir: str = ""):
         return (vrv_getformattedtype("{0}".format(ref[0])), "")
     # Finally from val lists
     vl = definition[0].find("tei:valList[@type=\"closed\"]", namespaces=TEI_RNG_NS)
-    if vl:
+    if vl is not None:
         element = vl.xpath("./ancestor::tei:classSpec", namespaces=TEI_RNG_NS)
         attName = vl.xpath("./parent::tei:attDef/@ident",
                            namespaces=TEI_RNG_NS)


### PR DESCRIPTION
This PR removes the special `att.surface` and makes `page` element part of `att.facsimile`. Closes #25.

The compiled ODD has been regenerated on MEI's latest development version .